### PR TITLE
remove kubeversion from chart metadata

### DIFF
--- a/helm/cluster-vsphere/Chart.yaml
+++ b/helm/cluster-vsphere/Chart.yaml
@@ -5,7 +5,6 @@ description: "A helm chart for creating Cluster API clusters with the vSphere pr
 keywords:
 - capv
 - vsphere
-kubeVersion: ">=1.19.0 < 1.23.0"
 maintainers:
 - name: Team Rocket
   email: team-rocket@giantswarm.io


### PR DESCRIPTION
there's no point restricting this to specific kubeversions as they are only CRs.
