### PR TITLE
Fix CoreDNS configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing files for CoreDNS configuration by cluster-shared.
+
 ## [0.2.0] - 2023-03-20
 
 ### Added

--- a/helm/cluster-vsphere/templates/coredns.yaml
+++ b/helm/cluster-vsphere/templates/coredns.yaml
@@ -1,0 +1,2 @@
+# use the `_coredns.tpl` from `cluster-shared`
+{{- include "coredns" .}}

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -104,6 +104,8 @@ cluster:
   # enable encryption at REST feature of API server
   enableEncryptionProvider: true
 
+# cluster-shared configuration
+includeClusterResourceSet: "true"  # must be a string
 # let's use the kubectl image defaults
 kubectlImage:
   registry: quay.io


### PR DESCRIPTION
CoreDNS network policies and configuration are missing now. This PR fixes it. 

See https://github.com/giantswarm/cluster-shared/blob/main/helm/cluster-shared/templates/_coredns.tpl#L1

See https://github.com/giantswarm/cluster-cloud-director/blob/main/helm/cluster-cloud-director/templates/coredns.yaml

Verified in `gerkan`.