### PR TITLE
Missing space (yaml indentation)

### DIFF
--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -164,7 +164,7 @@ mount containerd configuration for registry configuration in nodes.
 {{- define "registryFiles" -}}
 {{- if and .Values.connectivity .Values.connectivity.containerRegistries -}}
 - path: /etc/containerd/conf.d/registry-config.toml
- permissions: "0600"
+  permissions: "0600"
   contentFrom:
     secret:
       name: {{ include "registrySecretName" $ }}


### PR DESCRIPTION
fixing:
```
---> Deploying MC helm chart
secret/vsphere-credentials created
+ helm repo add --force-update cluster-catalog https://giantswarm.github.io/cluster-catalog/
"cluster-catalog" has been added to your repositories
+ helm upgrade --install --kubeconfig=./kubeconfigs/kind-mc-initial-gjiri.kubeconfig --version v0.2.1 --values ./secrets/values.yaml --set cluster.name=gjiri -f ./secrets/vsphere-credentials.yaml -f ./secrets/gjiri-container-registries-configuration.yaml -n org-giantswarm gjiri cluster-catalog/cluster-vsphere
Release "gjiri" does not exist. Installing it now.
Error: YAML parse error on cluster-vsphere/templates/kubeadmconfigtemplate.yaml: error converting YAML to JSON: yaml: line 57: did not find expected '-' indicator
```