### PR TITLE
Improve cluster parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `cloud-provider-vsphere` version to `1.3.2`.
+- Use release name instead of `cluster.name`.
+- Move `organization` to root level for uniformity.
 
 ## [0.2.1] - 2023-03-21
 

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -65,7 +65,7 @@ helm.sh/chart: {{ include "chart" . | quote }}
 Create a prefix for all resource names.
 */}}
 {{- define "resource.default.name" -}}
-{{ .Values.cluster.name }}
+{{ .Release.Name }}
 {{- end -}}
 
 {{- define "securityContext.runAsUser" -}}

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -6,15 +6,6 @@
                 "kubernetesVersion": {
                     "title": "Kubernetes version",
                     "type": "string"
-                },
-                "name": {
-                    "description": "Unique identifier, cannot be changed after creation.",
-                    "title": "Cluster name",
-                    "type": "string"
-                },
-                "organization": {
-                    "title": "Organization",
-                    "type": "string"
                 }
             },
             "title": "Cluster",
@@ -124,6 +115,10 @@
             },
             "title": "Network",
             "type": "object"
+        },
+        "organization": {
+            "title": "Organization",
+            "type": "string"
         },
         "template": {
             "description": "Provisioning options for node templates.",

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -5,6 +5,7 @@ controllerManager:
   featureGates: "ExpandPersistentVolumes=true,TTLAfterFinished=true"
 
 clusterDescription: ""  # Cluster description used in metadata.
+organization: ""  # The organization which owns this cluster.
 
 servicePriority: "highest"
 clusterLabels: {}
@@ -94,12 +95,6 @@ oidc:
 cluster:
   # Kubernetes version to deploy. Must match the version available in the image defined at template
   kubernetesVersion: ""
-
-  # Cluster name; used as a base for names of all cluster resources.
-  name: ""
-
-  # The organization which owns this cluster.
-  organization: ""
 
   # enable encryption at REST feature of API server
   enableEncryptionProvider: true


### PR DESCRIPTION
`organization` should be at the root level as other providers. Chart already assumes in that way. See https://github.com/giantswarm/cluster-vsphere/blob/main/helm/cluster-vsphere/templates/_helpers.tpl#L50

The location of the parameter was wrong in values.yaml and schema.

---

We use the release name for cluster name in other providers and it is easy to use.
