### PR TITLE
Add default-test HelmRepository (catalog) for debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `default-test` HelmRepository (catalog) for debugging.
+
 ### Changed
 
 - Bump `cloud-provider-vsphere` version to `1.3.3`.
+
+### Removed
+
+- Remove unnecessary labels from HelmRepository CR.
 
 ## [0.3.0] - 2023-03-27
 

--- a/helm/cluster-vsphere/templates/default-helmrepository.yaml
+++ b/helm/cluster-vsphere/templates/default-helmrepository.yaml
@@ -6,9 +6,20 @@ metadata:
   annotations:
     cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
   labels:
-    cluster-apps-operator.giantswarm.io/watching: ""
-    giantswarm.io/service-priority: "{{ .Values.servicePriority }}"
     {{- include "labels.common" . | nindent 4 }}
 spec:
   interval: 10m
   url: https://giantswarm.github.io/default-catalog
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: {{ include "resource.default.name" $ }}-default-test
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  interval: 10m
+  url: https://giantswarm.github.io/default-test-catalog


### PR DESCRIPTION
When debugging someone may want to set `HelmRelease` version to something like:

```
      sourceRef:
        kind: HelmRepository
        name: pawe2-default-test
      version: 0.6.1-asdfasdfasdfasdfasdf
```

with this change `pawe2-default-test` will be installed with the helm chart and does not have to be created manually. Yes it won't be used by default but I don't think that hurts.