### PR TITLE
Add an option to add custom certSANs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `MachineHealthCheck` for worker nodes.
 - Add `loadBalancersCidrBlocks` parameter that is used by kube-vip for `LoadBalancer` services.
+- Add `apiServer.certSANs` option.
 
 ## [0.3.1] - 2023-04-05
 

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -17,7 +17,7 @@ spec:
         {{- with .Values.apiServer.certSANs }}
           {{- range . }}
         - {{ . }}
-          {{- end }}
+        {{- end }}
         {{- end }}
         extraArgs:
           cloud-provider: external

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -15,7 +15,7 @@ spec:
         - 127.0.0.1
         - "api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
         {{- with .Values.apiServer.certSANs }}
-          {{- range . }}
+        {{- range . }}
         - {{ . }}
         {{- end }}
         {{- end }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -14,6 +14,11 @@ spec:
         - localhost
         - 127.0.0.1
         - "api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
+        {{- with .Values.apiServer.certSANs }}
+          {{- range . }}
+        - {{ . }}
+          {{- end }}
+        {{- end }}
         extraArgs:
           cloud-provider: external
           enable-admission-plugins: {{ .Values.apiServer.enableAdmissionPlugins }}

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -11,6 +11,38 @@
             "title": "Cluster",
             "type": "object"
         },
+        "apiServer": {
+            "properties": {
+                "certSANs": {
+                    "default": [],
+                    "description": "Alternative names to encode in the API server's certificate.",
+                    "items": {
+                        "title": "SAN",
+                        "type": "string"
+                    },
+                    "title": "Subject alternative names (SAN)",
+                    "type": "array"
+                },
+                "enableAdmissionPlugins": {
+                    "default": "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook",
+                    "description": "Comma-separated list of admission plugins to enable.",
+                    "title": "Admission plugins",
+                    "type": "string"
+                },
+                "featureGates": {
+                    "default": "TTLAfterFinished=true",
+                    "description": "Enabled feature gates, as a comma-separated list.",
+                    "title": "Feature gates",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "enableAdmissionPlugins",
+                "featureGates"
+            ],
+            "title": "Kubernetes API server",
+            "type": "object"
+        },
         "controlPlane": {
             "properties": {
                 "endpoint": {

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -1,6 +1,7 @@
 apiServer:
   enableAdmissionPlugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"
   featureGates: "TTLAfterFinished=true"
+  certSANs: []
 controllerManager:
   featureGates: "ExpandPersistentVolumes=true,TTLAfterFinished=true"
 


### PR DESCRIPTION
```
helm template foo helm/cluster-vsphere --set "apiServer.certSANs={'1.1.1.1','2.2.2.2'}" | grep -A6 -i sans                                                     
        certSANs:
        - localhost
        - 127.0.0.1
        - "api.foo."
        - '1.1.1.1'
        - '2.2.2.2'
        extraArgs:
```

also the json schema for elements under `apiServer.*` were missing