### PR TITLE
Set .network.servicesCidrBlocks value in Cluster CR and change default pod and service networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `loadBalancersCidrBlocks` parameter that is used by kube-vip for `LoadBalancer` services.
 - Add `apiServer.certSANs` option.
 
+### Fixed
+
+- Set `.network.servicesCidrBlocks` value in Cluster CR.
+
 ## [0.3.1] - 2023-04-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve schema and ci values.
+- :boom: **Breaking:** Change default pod network and service network to 10.244.0.0/16 and 10.96.0.0/16.
 
 ### Added
 

--- a/helm/cluster-vsphere/templates/cluster.yaml
+++ b/helm/cluster-vsphere/templates/cluster.yaml
@@ -16,14 +16,14 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-      {{- range .Values.network.podsCidrBlocks }}
-      - {{ . }}
-      {{- end }}
-    # services:
-    #   cidrBlocks:
-    #   {{- range .Values.network.servicesCidrBlocks }}
-    #   - {{ . }}
-    #   {{- end }}
+        {{- range .Values.network.podsCidrBlocks }}
+        - {{ . }}
+        {{- end }}
+    services:
+      cidrBlocks:
+        {{- range .Values.network.servicesCidrBlocks }}
+        - {{ . }}
+        {{- end }}
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -12,9 +12,9 @@ servicePriority: "highest"
 clusterLabels: {}
 network:
   podsCidrBlocks:
-  - "192.168.0.0/16"
+  - "10.244.0.0/16"
   servicesCidrBlocks:
-  - "192.168.1.0/16"
+  - "10.96.0.0/16"
   loadBalancersCidrBlocks: []
   controlPlaneEndpoint:
     host: ""  # [string] Manually select an IP for kube API. "" for auto selection from pool.


### PR DESCRIPTION
I need it for https://github.com/giantswarm/cluster-vsphere/pull/52. I'll test it with https://github.com/giantswarm/cluster-vsphere/pull/52.

I also change the default networks to  `10.244.0.0/16` (pod) and `10.96.0.0/16` (service) as defined in https://github.com/giantswarm/giantswarm/issues/26451 because previous values were basically the same network.