### PR TITLE
[wip] First shot for topology@vSphere

### DIFF
--- a/helm/cluster-vsphere/ci/ci-values.yaml
+++ b/helm/cluster-vsphere/ci/ci-values.yaml
@@ -17,6 +17,9 @@ vcenter:
   thumbprint: "F7:CF:F9:E5:99:39:FF:C1:D7:14:F1:3F:8A:42:21:95:3B:A1:6E:16"
   region: "k8s-region"
   zone: "k8s-zone"
+  regionTag: "ionos-region"
+  computeCluster: "Cluster1"
+  autoConfigureTopology: true
 controlPlane:
   replicas: 1
   machineTemplate:

--- a/helm/cluster-vsphere/templates/topology.yaml
+++ b/helm/cluster-vsphere/templates/topology.yaml
@@ -1,0 +1,57 @@
+{{- range $name, $value := (merge .Values.nodeClasses (dict "control-plane" .Values.controlPlane.machineTemplate)) }}
+{{- $c := (merge (dict "currentClass"  $value) $.Values) }}
+{{- if and ($value.failureDomain) ($.Values.vcenter.regionTag) }}
+{{- /*
+{{- $c | mustToPrettyJson | printf "\nThe JSON output of the dumped var is: \n%s" | fail }}
+*/ -}}
+---
+# Region -> ComputeCluster, Zone -> HostGroup
+# CAPV will create vm groups matching the host groups,
+# then create vm-host affinity rules between vmgroups and hostgroups,
+# add the CP node to the specific vm group, DRS will schedule the VM to the corresponding hostgroup.
+
+apiVersion: {{ include "infrastructureApiVersion" . }}
+kind: VSphereFailureDomain
+metadata:
+  name: {{ include "resource.default.name" $ }}-{{ $value.failureDomain }}-{{ include "mtRevision" $c }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+spec:
+  region:
+    name: {{ $.Values.vcenter.regionTag }}
+    type: ComputeCluster
+    tagCategory: {{ $.Values.vcenter.region }}
+    autoConfigure: {{ $.Values.vcenter.autoConfigureTopology }}
+  zone:
+    name: {{ $value.failureDomain }}
+    type: HostGroup
+    tagCategory: {{ $.Values.vcenter.zone }}
+    autoConfigure: {{ $.Values.vcenter.autoConfigureTopology }}
+  topology:
+    datacenter: {{ $value.datacenter | default $.Values.vcenter.datacenter }}
+    computeCluster: {{ $.Values.vcenter.computeCluster }}
+    hosts:
+      # host group needs to be precreated, vm group will be created by capv controller
+      # name of the host group is assumed to be the same as the name of the node class (default, control-plane, etc.)
+      vmGroupName: {{ include "resource.default.name" $ }}-{{ $value.failureDomain }}-{{ include "mtRevision" $c }}
+      hostGroupName: {{ $name }}
+    datastore: {{ $value.datastore | default $.Values.vcenter.datastore }}
+    networks:
+{{- range $value.network.devices }}
+    - {{ .networkName }}
+{{- end }}
+---
+apiVersion: {{ include "infrastructureApiVersion" . }}
+kind: VSphereDeploymentZone
+metadata:
+ name: {{ include "resource.default.name" $ }}-{{ $value.failureDomain }}-{{ include "mtRevision" $c }}
+spec:
+ server: {{ $.Values.vcenter.server }}
+ failureDomain: {{ include "resource.default.name" $ }}-{{ $value.failureDomain }}-{{ include "mtRevision" $c }}
+ placementConstraint:
+   resourcePool: {{ $value.resourcePool }}
+   folder: {{ $value.folder }}
+---
+{{- end }}
+{{- end }}

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -17,6 +17,7 @@ controlPlane:  # Must match nodeClasses' fields except "name" and must contain "
     template: "ubuntu-2004-kube-v1.24.11"  # template used to create (or) upgrade control plane nodes.
     resourcePool: ""  # ResourcePool is the name or inventory path of the resource pool in which the virtual machine is created/located.
     memoryMiB: 8192
+    failureDomain: ""
     network:
       devices:
       - dhcp4: true
@@ -67,6 +68,12 @@ vcenter:
 
   # Category name in VSphere for topology.kubernetes.io/region label
   region: ""
+
+  # Tag name in VSphere for topology.kubernetes.io/region label (basically tag for region category)
+  regionTag: ""
+
+  # Used only when topology is on
+  computeCluster: ""
 
   # Category name in VSphere for topology.kubernetes.io/zone label
   zone: ""


### PR DESCRIPTION
This pr: creates 2 new CRs for each nodeClass (+1 for control plane)
- `VSphereFailureDomain`
- `VSphereDeploymentZone`

The docs for this feature in capv provider are pretty convoluted, but to my knowledge the Host groups & DRS rules need to be pre-created and then the capv controller will create vm group and add those vms into that group. This is not tested against a vCenter where we have sufficient RBAC set.


currently when deployed by:
```
helm --debug install test . -f ci/ci-values.yaml --set nodeClasses.default.failureDomain=foo --set controlPlane.machineTemplate.failureDomain=bar
```
 it fails on:
```
E0601 10:34:46.876783       1 vspheredeploymentzone_controller.go:158] "capv-controller-manager/vspheredeploymentzone-controller: unable to create session" err="Post \"https://foo.example.com/sdk\": dial tcp: lookup foo.example.com on 10.96.0.10:53: no such host" vspheredeploymentzone="test-foo-9977a4e6"
```

So it looks like it's trying to use the `failureDomain` value as address for vcenter `¯\_(ツ)_/¯`, no docs at all. So it is gonna be another reverse engineering journey.

<details>
  <summary>How to run CI</summary>

Comment on this PR with:

```
/run cluster-test-suites
```
</details>