### PR TITLE
Add controlplane ip explicitly to certSANs list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `connectivity.network.controlPlaneEndpoint.host` to `certSANs` list.
+
 ## [0.5.0] - 2023-05-22
 
 ### Changed

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -12,7 +12,7 @@ spec:
         certSANs:
         - localhost
         - 127.0.0.1
-        - {{ .Values.connectivity.network.controlPlaneEndpoint }}
+        - {{ .Values.connectivity.network.controlPlaneEndpoint.host }}
         - "api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
         {{- with .Values.apiServer.certSANs }}
         {{- range . }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -1,4 +1,3 @@
-#todo: this
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
@@ -13,6 +12,7 @@ spec:
         certSANs:
         - localhost
         - 127.0.0.1
+        - {{ .Values.connectivity.network.controlPlaneEndpoint }}
         - "api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
         {{- with .Values.apiServer.certSANs }}
         {{- range . }}


### PR DESCRIPTION
that should help when changing the IP of control plane later on and certs need to be recreated
