### PR TITLE
Bump coredns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump the version of coredns-app to `1.16.0`
 - :boom: **Breaking:** Stop deploying default network policies with the `cilium-app`. This means the cluster will be more locked down and all network traffic is blocked by default. Can be disabled with `network.allowAllEgress` setting. Requires `default-apps-vsphere@v0.9.2`.
 - Bumped default k8s version to `1.24`, this might be :boom: **Breaking:**
 - `.cluster.kubernetesVersion`: `v1.22.5+vmware.1` -> `v1.24.11`

--- a/helm/cluster-vsphere/templates/coredns-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/coredns-helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     spec:
       chart: coredns-app
-      version: 1.15.0
+      version: 1.16.0
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default


### PR DESCRIPTION
`1.16.0` has nodeSelector set to `node-role.kubernetes.io/control-plane=`
cc @vxav (you made the change on coredns-app so pinging you :)

current issue:
```
kube-system   coredns-controlplane-8b445ddfb-t6klq                             0/1     Pending   0             2m2s
```

```
kubectl --kubeconfig=./kubeconfigs/gjiri.kubeconfig describe pod coredns-controlplane-8b445ddfb-t6klq -n kube-system
...
Node-Selectors:              node-role.kubernetes.io/master=
Tolerations:                 node-role.kubernetes.io/control-plane:NoSchedule op=Exists
                             node-role.kubernetes.io/master:NoSchedule op=Exists
                             node.cloudprovider.kubernetes.io/uninitialized op=Exists
                             node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason            Age                    From               Message
  ----     ------            ----                   ----               -------
  Warning  FailedScheduling  2m40s (x2 over 2m41s)  default-scheduler  0/4 nodes are available: 4 node(s) didn't match Pod's node affinity/selector. preemption: 0/4 nodes are available: 4 Preemption is not helpful for scheduling.
```


```
kubectl --kubeconfig=./kubeconfigs/gjiri.kubeconfig describe no gjiri-j7wzx
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-7gb.os-ubuntu
                    beta.kubernetes.io/os=linux
                    failure-domain.beta.kubernetes.io/region=ionos-region
                    failure-domain.beta.kubernetes.io/zone=ionos-zone
                    kubernetes.io/arch=amd64
                    kubernetes.io/hostname=gjiri-j7wzx
                    kubernetes.io/os=linux
                    node-role.kubernetes.io/control-plane=
                    node.cluster.x-k8s.io/esxi-host=esxi02-rhr3c72bx1.ionoscloud.tools
                    node.kubernetes.io/exclude-from-external-load-balancers=
                    node.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-7gb.os-ubuntu
                    topology.kubernetes.io/region=ionos-region
                    topology.kubernetes.io/zone=ionos-zone
```