### PR TITLE
Add 'resource-policy: keep' annotation on some resources so that helm won't delete them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `"helm.sh/resource-policy": "keep"` annotation to VSphereCluster,
   MachineDeployments and KubeadmControlPlane. The deletion of these resources
-  has to be done in certaion order and must be handled by the CAPI and CAPA controllers.
+  has to be done in certain order and must be handled by the CAPI and CAPV controllers.
 
 ## [0.6.1] - 2023-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `connectivity.network.controlPlaneEndpoint.host` to `certSANs` list.
+- Add `"helm.sh/resource-policy": "keep"` annotation to VSphereCluster,
+  MachineDeployments and KubeadmControlPlane. The deletion of these resources
+  has to be done in certaion order and must be handled by the CAPI and CAPA controllers.
 
 ## [0.5.1] - 2023-06-07
 

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -75,10 +75,6 @@ Create a prefix for all resource names.
 1000
 {{- end -}}
 
-{{- define "helm-keep" -}}
-"helm.sh/resource-policy": "keep"
-{{- end -}}
-
 {{- define "kubeletExtraArgs" -}}
 {{- .Files.Get "files/kubelet-args" -}}
 {{- end -}}

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -75,6 +75,10 @@ Create a prefix for all resource names.
 1000
 {{- end -}}
 
+{{- define "helm-keep" -}}
+"helm.sh/resource-policy": "keep"
+{{- end -}}
+
 {{- define "kubeletExtraArgs" -}}
 {{- .Files.Get "files/kubelet-args" -}}
 {{- end -}}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
   annotations:
-    {{- include "helm-keep" . | nindent 4 }}
+    helm.sh/resource-policy: "keep"
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
+  annotations:
+    {{- include "helm-keep" . | nindent 4 }}
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:

--- a/helm/cluster-vsphere/templates/machinedeployment.yaml
+++ b/helm/cluster-vsphere/templates/machinedeployment.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "labels.common" $ | nindent 4 }}
   annotations:
-    {{- include "helm-keep" $ | nindent 4 }}
+    helm.sh/resource-policy: "keep"
 spec:
   clusterName: {{ include "resource.default.name" $ }}
   replicas: {{ $value.replicas }}

--- a/helm/cluster-vsphere/templates/machinedeployment.yaml
+++ b/helm/cluster-vsphere/templates/machinedeployment.yaml
@@ -7,6 +7,8 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
+  annotations:
+    {{- include "helm-keep" $ | nindent 4 }}
 spec:
   clusterName: {{ include "resource.default.name" $ }}
   replicas: {{ $value.replicas }}

--- a/helm/cluster-vsphere/templates/provider-secret.yaml
+++ b/helm/cluster-vsphere/templates/provider-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
   annotations: # this will be deleted by cluster-api-cleaner-vsphere controller
-    {{- include "helm-keep" . | nindent 4 }}
+    helm.sh/resource-policy: "keep"
 data:
   username: {{ .Values.vcenter.username | b64enc | quote }}
   password: {{ .Values.vcenter.password | b64enc | quote }}

--- a/helm/cluster-vsphere/templates/provider-secret.yaml
+++ b/helm/cluster-vsphere/templates/provider-secret.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "credentialSecretName" $ }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
+  annotations: # this will be deleted by cluster-api-cleaner-vsphere controller
+    {{- include "helm-keep" . | nindent 4 }}
 data:
   username: {{ .Values.vcenter.username | b64enc | quote }}
   password: {{ .Values.vcenter.password | b64enc | quote }}

--- a/helm/cluster-vsphere/templates/vspherecluster.yaml
+++ b/helm/cluster-vsphere/templates/vspherecluster.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
   annotations:
-    {{- include "helm-keep" . | nindent 4 }}
+    helm.sh/resource-policy: "keep"
 spec:
   controlPlaneEndpoint:
     host: '{{ ((.Values.connectivity.network).controlPlaneEndpoint).host }}'

--- a/helm/cluster-vsphere/templates/vspherecluster.yaml
+++ b/helm/cluster-vsphere/templates/vspherecluster.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
+  annotations:
+    {{- include "helm-keep" . | nindent 4 }}
 spec:
   controlPlaneEndpoint:
     host: '{{ ((.Values.connectivity.network).controlPlaneEndpoint).host }}'


### PR DESCRIPTION
Instead, we rely on the `cap{i,v}` controllers

context: https://gigantic.slack.com/archives/C01F7T2MNRL/p1686149914450729

