### PR TITLE
Bind `kube-scheduler` metrics to 0.0.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `connectivity.network.controlPlaneEndpoint.host` to `certSANs` list.
+- Bind `kube-scheduler` metrics to 0.0.0.0.
 
 ## [0.5.1] - 2023-06-07
 

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -86,11 +86,11 @@ spec:
           imageRepository: {{ .Values.controlPlane.etcd.imageRepository }}
           imageTag: {{ .Values.controlPlane.etcd.imageTag }}
       imageRepository: {{ .Values.controlPlane.image.repository }}
-      {{- include "sshUsers" . | nindent 4 }}
       scheduler:
         extraArgs:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
           bind-address: "0.0.0.0"
+    {{- include "sshUsers" . | nindent 4 }}
     initConfiguration:
       skipPhases:
         - addon/coredns

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -87,6 +87,10 @@ spec:
           imageTag: {{ .Values.controlPlane.etcd.imageTag }}
       imageRepository: {{ .Values.controlPlane.image.repository }}
       {{- include "sshUsers" . | nindent 4 }}
+      scheduler:
+        extraArgs:
+          authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
+          bind-address: "0.0.0.0"
     initConfiguration:
       skipPhases:
         - addon/coredns


### PR DESCRIPTION
This pr: ..

<details>
  <summary>How to run CI</summary>

Comment on this PR with:

```
/run cluster-test-suites
```
</details>