### PR TITLE
Set value for terminated pod gc threshold to be consistent with vintage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Set value for `controller-manager` `terminated-pod-gc-threshold` to `125` ( consistent with vintage ) 
+
 ## [0.6.0] - 2023-07-04
 
 ### Added

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -73,6 +73,7 @@ spec:
           bind-address: "0.0.0.0"
           cloud-provider: external
           enable-hostpath-provisioner: "true"
+          terminated-pod-gc-threshold: "125"
           feature-gates: {{ .Values.controllerManager.featureGates }}
           logtostderr: "true"
           profiling: "false"


### PR DESCRIPTION
Towards https://github.com/giantswarm/klingel/issues/91

This pr:

- Set value for terminated pod gc threshold to be consistent with vintage

<details>
  <summary>How to run CI</summary>

Comment on this PR with:

```
/run cluster-test-suites
```
</details>