### PR TITLE
Bump cloud-provider-vsphere version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Set value for `controller-manager` `terminated-pod-gc-threshold` to `125` ( consistent with vintage ) 
+- Set value for `controller-manager` `terminated-pod-gc-threshold` to `125` ( consistent with vintage )
+- Bump `cloud-provider-vsphere` version to `1.5.0` 
 
 ## [0.6.0] - 2023-07-04
 

--- a/helm/cluster-vsphere/templates/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/cloud-provider-vsphere-helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
   chart:
     spec:
       chart: cloud-provider-vsphere
-      version: 1.4.0
+      version: 1.5.0
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default


### PR DESCRIPTION
Bumps cloud-provider-vsphere to latest

<details>
  <summary>How to run CI</summary>

Comment on this PR with:

```
/run cluster-test-suites
```
</details>