### PR TITLE
Customizable timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add a way to customize the timeout in `HelmRelease.spec`.
 - Set value for `controller-manager` `terminated-pod-gc-threshold` to `125` ( consistent with vintage )
 - Bump `cloud-provider-vsphere` version to `1.5.0` 
 

--- a/helm/cluster-vsphere/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/cilium-helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
   kubeConfig:
     secretRef:
       name: {{ include "resource.default.name" $ }}-kubeconfig
-  interval: 5m
+  interval: {{ .Values.helmReleases.cilium.interval | default "5m" }}
   install:
     remediation:
       retries: 30

--- a/helm/cluster-vsphere/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/cilium-helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
   kubeConfig:
     secretRef:
       name: {{ include "resource.default.name" $ }}-kubeconfig
-  interval: {{ .Values.helmReleases.cilium.interval | default "5m" }}
+  interval: {{ ((.Values.helmReleases).cilium).interval | default "5m" }}
   install:
     remediation:
       retries: 30

--- a/helm/cluster-vsphere/templates/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/cloud-provider-vsphere-helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
   kubeConfig:
     secretRef:
       name: {{ include "resource.default.name" $ }}-kubeconfig
-  interval: 10m
+  interval: {{ $.Values.helmReleases.cpi.interval | default "10m" }}
   install:
     remediation:
       retries: 30

--- a/helm/cluster-vsphere/templates/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/cloud-provider-vsphere-helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
   kubeConfig:
     secretRef:
       name: {{ include "resource.default.name" $ }}-kubeconfig
-  interval: {{ $.Values.helmReleases.cpi.interval | default "10m" }}
+  interval: {{ .Values.helmReleases.cpi.interval | default "10m" }}
   install:
     remediation:
       retries: 30

--- a/helm/cluster-vsphere/templates/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/cloud-provider-vsphere-helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
   kubeConfig:
     secretRef:
       name: {{ include "resource.default.name" $ }}-kubeconfig
-  interval: {{ .Values.helmReleases.cpi.interval | default "10m" }}
+  interval: {{ ((.Values.helmReleases).cpi).interval | default "10m" }}
   install:
     remediation:
       retries: 30

--- a/helm/cluster-vsphere/templates/coredns-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/coredns-helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
   kubeConfig:
     secretRef:
       name: {{ include "resource.default.name" $ }}-kubeconfig
-  interval: 10m
+  interval: {{ .Values.helmReleases.coredns.interval | default "10m" }}
   install:
     remediation:
       retries: 30

--- a/helm/cluster-vsphere/templates/coredns-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/coredns-helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
   kubeConfig:
     secretRef:
       name: {{ include "resource.default.name" $ }}-kubeconfig
-  interval: {{ .Values.helmReleases.coredns.interval | default "10m" }}
+  interval: {{ ((.Values.helmReleases).coredns).interval | default "10m" }}
   install:
     remediation:
       retries: 30


### PR DESCRIPTION
This pr: adds a way to change the timeouts for helm releases. Since it's not part of public API, there are no defaults in the `values.yaml` file