### PR TITLE
InClusterIPPool -> GlobalInClusterIPPool (namespace scope not required)

### DIFF
--- a/helm/cluster-vsphere/templates/ipam/ipAddressClaim.yaml
+++ b/helm/cluster-vsphere/templates/ipam/ipAddressClaim.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   poolRef:
     apiGroup: ipam.cluster.x-k8s.io
-    kind: InClusterIPPool
+    kind: GlobalInClusterIPPool
     name: {{ .Values.connectivity.network.controlPlaneEndpoint.ipPoolName }}
 {{- end -}}


### PR DESCRIPTION
I didn't realise that `InClusterIPPool` were namespace scoped. The global CR should work, otherwise the `InClusterIPPool` would need to be installed for each organisation and with different ip range. However if that's something that a customer needs, it's easy to switch back or even make this configurable.