### PR TITLE
Consolidate containerd config.toml into single file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Consolidate containerd `config.toml` into single file to address [#1737](https://github.com/giantswarm/roadmap/issues/1737)
+
 ## [0.6.1] - 2023-07-13
 
 ### Added

--- a/helm/cluster-vsphere/files/etc/containerd/config.toml
+++ b/helm/cluster-vsphere/files/etc/containerd/config.toml
@@ -1,0 +1,50 @@
+version = 2
+
+# recommended defaults from https://github.com/containerd/containerd/blob/main/docs/ops.md#base-configuration
+# set containerd as a subreaper on linux when it is not running as PID 1
+subreaper = true
+# set containerd's OOM score
+oom_score = -999
+disabled_plugins = []
+[plugins."containerd.runtime.v1.linux"]
+# shim binary name/path
+shim = "containerd-shim"
+# runtime binary name/path
+runtime = "runc"
+# do not use a shim when starting containers, saves on memory but
+# live restore is not supported
+no_shim = false
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+# setting runc.options unsets parent settings
+runtime_type = "io.containerd.runc.v2"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+SystemdCgroup = true
+[plugins."io.containerd.grpc.v1.cri"]
+sandbox_image = "{{ .Values.internal.sandboxContainerImage.registry }}/{{ .Values.internal.sandboxContainerImage.name }}:{{ .Values.internal.sandboxContainerImage.tag }}"
+
+[plugins."io.containerd.grpc.v1.cri".registry]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+  {{- range $host, $config := .Values.connectivity.containerRegistries }}
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{$host}}"]
+      endpoint = [
+        {{- range $value := $config -}}
+        "https://{{$value.endpoint}}",
+        {{- end -}}
+    ]
+  {{- end }}
+[plugins."io.containerd.grpc.v1.cri".registry.configs]
+  {{ range $host, $config := .Values.connectivity.containerRegistries -}}
+    {{ range $value := $config -}}
+      {{ with $value.credentials -}}
+      [plugins."io.containerd.grpc.v1.cri".registry.configs."{{$value.endpoint}}".auth]
+      {{ if and .username .password -}}
+      auth = {{ printf "%s:%s" .username .password | b64enc | quote }}
+      {{- else if .auth -}}
+      auth = {{ .auth | quote }}
+      {{ else if .identitytoken -}}
+      identitytoken = {{ .identitytoken  | quote }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -156,7 +156,7 @@ mount containerd configuration.
   permissions: "0600"
   contentFrom:
     secret:
-      name: {{ include "registrySecretName" $ }}
+      name: {{ include "containerdConfigSecretName" $ }}
       key: registry-config.toml
 {{- end -}}
 
@@ -173,7 +173,7 @@ Generate name of the k8s secret that contains containerd configuration for regis
 When there is a change in the secret, it is not recognized by CAPI controllers.
 To enforce upgrades, a version suffix is appended to secret name.
 */}}
-{{- define "registrySecretName" -}}
+{{- define "containerdConfigSecretName" -}}
 {{- $secretSuffix := tpl ($.Files.Get "files/etc/containerd/config.toml") $ | b64enc | quote | sha1sum | trunc 8 }}
 {{- include "resource.default.name" $ }}-registry-configuration-{{$secretSuffix}}
 {{- end -}}

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -104,7 +104,7 @@ joinConfiguration:
       node-labels: "giantswarm.io/node-pool={{ .pool.name }}"
 files:
   {{- include "sshFiles" . | nindent 2}}
-  {{- include "registryFiles" . | nindent 2 }}
+  {{- include "containerdConfig" . | nindent 2 }}
   {{- if $.Values.proxy.enabled }}
     {{- include "containerdProxyConfig" . | nindent 2}}
   {{- end }}
@@ -149,17 +149,15 @@ postKubeadmCommands:
 
 {{/*
 Generate a stanza for KubeAdmConfig and KubeAdmControlPlane in order to 
-mount containerd configuration for registry configuration in nodes.
+mount containerd configuration.
 */}}
-{{- define "registryFiles" -}}
-{{- if and .Values.connectivity .Values.connectivity.containerRegistries -}}
-- path: /etc/containerd/conf.d/registry-config.toml
+{{- define "containerdConfig" -}}
+- path: /etc/containerd/config.toml
   permissions: "0600"
   contentFrom:
     secret:
       name: {{ include "registrySecretName" $ }}
       key: registry-config.toml
-{{- end -}}
 {{- end -}}
 
 
@@ -171,48 +169,12 @@ mount containerd configuration for registry configuration in nodes.
 {{- end -}}
 
 {{/*
-Generate the content of /etc/containerd/conf.d/registry-config.toml in nodes
-for registry configuration
-*/}}
-{{- define "registrySecretContent" -}}
-version = 2
-
-[plugins."io.containerd.grpc.v1.cri".registry]
-
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-{{- range $registry, $mirrors := .Values.connectivity.containerRegistries}}
-
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{$registry}}"]
-{{- $endpoints := list -}}
-{{- range $mirrors }}{{- $endpoints = append $endpoints .endpoint }}{{- end }}
-endpoint = [ "{{join "\" , \"" $endpoints}}" ]
-
-{{- end }}
-
-[plugins."io.containerd.grpc.v1.cri".registry.configs]
-
-{{- range $registry, $mirrors := .Values.connectivity.containerRegistries}}
-{{- range $mirrors }}
-
-{{- if .credentials }}
-[plugins."io.containerd.grpc.v1.cri".registry.configs."{{.endpoint}}".auth]
-{{- range $key, $value := .credentials }}
-{{ $key}}={{$value |quote}}
-{{- end }}
-{{ end }}
-
-{{- end }}
-{{- end }}
-
-{{- end -}}
-
-{{/*
 Generate name of the k8s secret that contains containerd configuration for registries.
 When there is a change in the secret, it is not recognized by CAPI controllers.
 To enforce upgrades, a version suffix is appended to secret name.
 */}}
 {{- define "registrySecretName" -}}
-{{- $secretSuffix := include "registrySecretContent" . | b64enc | quote | sha1sum | trunc 8 }}
+{{- $secretSuffix := tpl ($.Files.Get "files/etc/containerd/config.toml") $ | b64enc | quote | sha1sum | trunc 8 }}
 {{- include "resource.default.name" $ }}-registry-configuration-{{$secretSuffix}}
 {{- end -}}
 

--- a/helm/cluster-vsphere/templates/containerd-config-secret.yaml
+++ b/helm/cluster-vsphere/templates/containerd-config-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "registrySecretName" $ }}
+  name: {{ include "containerdConfigSecretName" $ }}
 data:
   registry-config.toml: {{ tpl ($.Files.Get "files/etc/containerd/config.toml") $ | b64enc | quote }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -122,7 +122,7 @@ spec:
       {{- if $.Values.proxy.enabled }}
       {{- include "containerdProxyConfig" . | nindent 6}}
       {{- end }}
-      {{- include "registryFiles" . | nindent 6 }}
+      {{- include "containerdConfig" . | nindent 6 }}
       {{- range $kubeadmPatch, $_ :=  .Files.Glob  "files/etc/patches/**" }}
       - path: {{ (printf "/tmp/kubeadm/patches/%s" (base $kubeadmPatch)) }}
         content: |-

--- a/helm/cluster-vsphere/templates/registry-secret.yaml
+++ b/helm/cluster-vsphere/templates/registry-secret.yaml
@@ -1,8 +1,6 @@
-{{- if and .Values.connectivity .Values.connectivity.containerRegistries -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "registrySecretName" $ }}
 data:
-  registry-config.toml: {{ include "registrySecretContent" . | b64enc | quote }}
-{{- end -}}
+  registry-config.toml: {{ tpl ($.Files.Get "files/etc/containerd/config.toml") $ | b64enc | quote }}

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -1,336 +1,414 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "$defs": {
-        "cidrBlocks": {
-            "items": {
-                "description": "IPv4 address range, in CIDR notation.",
-                "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(/([0-9]|[1,2][0-9]|[3][0-2]))?$",
-                 "examples": [
-                     "10.244.0.0/16"
-                 ],
-                 "type": "string"
-            },
-            "minItems": 1,
-            "maxItems": 1,
-            "type": "array"
-        }
-    },
-    "properties": {
-        "cluster": {
-            "properties": {
-                "kubernetesVersion": {
-                    "title": "Kubernetes version",
-                    "type": "string"
-                }
-            },
-            "title": "Cluster",
-            "type": "object"
-        },
-        "apiServer": {
-            "properties": {
-                "certSANs": {
-                    "default": [],
-                    "description": "Alternative names to encode in the API server's certificate.",
-                    "items": {
-                        "title": "SAN",
-                        "type": "string"
-                    },
-                    "title": "Subject alternative names (SAN)",
-                    "type": "array"
-                },
-                "enableAdmissionPlugins": {
-                    "default": "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook",
-                    "description": "Comma-separated list of admission plugins to enable.",
-                    "title": "Admission plugins",
-                    "type": "string"
-                },
-                "featureGates": {
-                    "default": "TTLAfterFinished=true",
-                    "description": "Enabled feature gates, as a comma-separated list.",
-                    "title": "Feature gates",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "enableAdmissionPlugins",
-                "featureGates"
-            ],
-            "title": "Kubernetes API server",
-            "type": "object"
-        },
-        "controlPlane": {
-            "properties": {
-                "etcd": {
-                    "properties": {
-                        "imageRepository": {
-                            "title": "Image repository",
-                            "type": "string"
-                        },
-                        "imageTag": {
-                            "title": "Image tag",
-                            "type": "string"
-                        }
-                    },
-                    "title": "Etcd",
-                    "type": "object"
-                },
-                "replicas": {
-                    "title": "Number of nodes",
-                    "type": "integer"
-                }
-            },
-            "title": "Control plane",
-            "type": "object"
-        },
-        "connectivity": {
-            "properties": {
-                "network": {
-                    "properties": {
-                        "allowAllEgress": {
-                            "default": false,
-                            "title": "Allow all egress",
-                            "type": "boolean"
-                        },
-                        "controlPlaneEndpoint": {
-                            "description": "Kubernetes API configuration.",
-                            "properties": {
-                                "host": {
-                                    "title": "Host",
-                                    "description": "IP for access to the Kubernetes API.",
-                                    "type": "string"
-                                },
-                                "port": {
-                                    "title": "Port number",
-                                    "description": "Port for access to the Kubernetes API.",
-                                    "type": "integer"
-                                },
-                                "ipPoolName": {
-                                    "title": "Ip Pool Name",
-                                    "description": "Ip for control plane will be drawn from this InClusterIPPool resource.",
-                                    "type": "string",
-                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
-                                    "default": "wc-cp-ips"
-                                }
-                            },
-                            "title": "Endpoint",
-                            "type": "object"
-                        },
-                        "pods": {
-                            "properties": {
-                                "cidrBlocks": {
-                                    "$ref": "#/$defs/cidrBlocks",
-                                    "default": "10.244.0.0/16",
-                                    "title": "Pod subnets"
-                                }
-                            },
-                            "required": [
-                                "cidrBlocks"
-                            ],
-                            "title": "Pods",
-                            "type": "object"
-                        },
-                        "services": {
-                            "properties": {
-                                "cidrBlocks": {
-                                    "$ref": "#/$defs/cidrBlocks",
-                                    "default": "172.31.0.0/16",
-                                    "title": "Service subnets"
-                                }
-                            },
-                            "required": [
-                                "cidrBlocks"
-                            ],
-                            "title": "Services",
-                            "type": "object"
-                        },
-                        "loadBalancers": {
-                            "properties": {
-                                "cidrBlocks": {
-                                    "$ref": "#/$defs/cidrBlocks",
-                                    "title": "Load Balancer subnets"
-                                }
-                            },
-                            "required": [
-                                "cidrBlocks"
-                            ],
-                            "title": "Load balancers",
-                            "type": "object"
-                        }
-                    },
-                    "required": [
-                        "pods",
-                        "services",
-                        "loadBalancers"
-                    ],
-                    "title": "Network",
-                    "type": "object"
-                }
-            },
-            "required": [
-                "network"
-            ],
-            "title": "Connectivity",
-            "type": "object"
-        },
-        "kubeadm": {
-            "properties": {
-                "users": {
-                    "items": {
-                        "properties": {
-                            "authorizedKeys": {
-                                "items": {
-                                    "title": "Key",
-                                    "type": "string"
-                                },
-                                "title": "Authorized keys",
-                                "type": "array"
-                            },
-                            "name": {
-                                "title": "Name",
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
-                    },
-                    "title": "Users",
-                    "type": "array"
-                }
-            },
-            "title": "Kubeadm",
-            "type": [
-                "null",
-                "object"
-            ]
-        },
-        "kubectlImage": {
-            "description": "Used by cluster-shared library chart to configure coredns in-cluster.",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "registry": {
-                    "type": "string"
-                },
-                "tag": {
-                    "type": "string"
-                }
-            },
-            "title": "Kubectl image",
-            "type": "object"
-        },
-        "organization": {
-            "title": "Organization",
-            "type": "string"
-        },
-        "template": {
-            "description": "Provisioning options for node templates.",
-            "properties": {
-                "cloneMode": {
-                    "description": "Method used to clone template image.",
-                    "title": "Clone mode",
-                    "type": "string"
-                },
-                "diskGiB": {
-                    "description": "Node disk size in GB. Must be at least as large as the source image.",
-                    "title": "Disk size (GB)",
-                    "type": "integer"
-                },
-                "folder": {
-                    "description": "VSphere folder to deploy instances in. Must already exist.",
-                    "title": "Folder",
-                    "type": "string"
-                },
-                "memoryMiB": {
-                    "description": "Node memory allocation in MB.",
-                    "title": "Memory (MB)",
-                    "type": "integer"
-                },
-                "networkName": {
-                    "description": "Segment name to attach nodes to. Must already exist.",
-                    "title": "Segment name",
-                    "type": "string"
-                },
-                "numCPUs": {
-                    "description": "Number of CPUs to assign per node.",
-                    "title": "CPU cores",
-                    "type": "integer"
-                },
-                "resourcePool": {
-                    "description": "Resource pool to allocate nodes from. Must already exist.",
-                    "title": "Resource pool",
-                    "type": "string"
-                },
-                "storagePolicyName": {
-                    "description": "Storage policy to use. If specified, it must already exist.",
-                    "title": "Storage policy",
-                    "type": "string"
-                },
-                "templateName": {
-                    "description": "Image template name to use for nodes.",
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "title": "Node template",
-            "type": "object"
-        },
-        "vcenter": {
-            "description": "Configuration for vSphere API access.",
-            "properties": {
-                "datacenter": {
-                    "description": "Name of the datacenter to deploy nodes into.",
-                    "title": "Datacenter",
-                    "type": "string"
-                },
-                "datastore": {
-                    "description": "Name of the datastore for node disk storage.",
-                    "title": "Datastore",
-                    "type": "string"
-                },
-                "server": {
-                    "description": "URL of the VSphere API.",
-                    "title": "Server",
-                    "type": "string"
-                },
-                "username": {
-                    "description": "Username for the VSphere API.",
-                    "title": "Username",
-                    "type": "string"
-                },
-                "password": {
-                    "description": "Password for the VSphere API.",
-                    "title": "Password",
-                    "type": "string"
-                },
-                "thumbprint": {
-                    "description": "TLS certificate signature of the VSphere API.",
-                    "title": "Thumbprint",
-                    "type": "string"
-                },
-                "region": {
-                    "description": "Category name in VSphere for topology.kubernetes.io/region labels.",
-                    "title": "Region",
-                    "type": "string"
-                },
-                "zone": {
-                    "description": "Category name in VSphere for topology.kubernetes.io/zone labels.",
-                    "title": "Zone",
-                    "type": "string"
-                }
-            },
-            "title": "VCenter",
-            "type": "object"
-        },
-        "worker": {
-            "properties": {
-                "replicas": {
-                    "title": "Number of nodes",
-                    "type": "integer"
-                }
-            },
-            "title": "Worker",
-            "type": "object"
-        }
-    },
-    "type": "object"
+	"$schema": "http://json-schema.org/schema#",
+	"$defs": {
+		"cidrBlocks": {
+			"items": {
+				"description": "IPv4 address range, in CIDR notation.",
+				"pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(/([0-9]|[1,2][0-9]|[3][0-2]))?$",
+				"examples": [
+					"10.244.0.0/16"
+				],
+				"type": "string"
+			},
+			"minItems": 1,
+			"maxItems": 1,
+			"type": "array"
+		}
+	},
+	"properties": {
+		"cluster": {
+			"properties": {
+				"kubernetesVersion": {
+					"title": "Kubernetes version",
+					"type": "string"
+				}
+			},
+			"title": "Cluster",
+			"type": "object"
+		},
+		"apiServer": {
+			"properties": {
+				"certSANs": {
+					"default": [],
+					"description": "Alternative names to encode in the API server's certificate.",
+					"items": {
+						"title": "SAN",
+						"type": "string"
+					},
+					"title": "Subject alternative names (SAN)",
+					"type": "array"
+				},
+				"enableAdmissionPlugins": {
+					"default": "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook",
+					"description": "Comma-separated list of admission plugins to enable.",
+					"title": "Admission plugins",
+					"type": "string"
+				},
+				"featureGates": {
+					"default": "TTLAfterFinished=true",
+					"description": "Enabled feature gates, as a comma-separated list.",
+					"title": "Feature gates",
+					"type": "string"
+				}
+			},
+			"required": [
+				"enableAdmissionPlugins",
+				"featureGates"
+			],
+			"title": "Kubernetes API server",
+			"type": "object"
+		},
+		"controlPlane": {
+			"properties": {
+				"etcd": {
+					"properties": {
+						"imageRepository": {
+							"title": "Image repository",
+							"type": "string"
+						},
+						"imageTag": {
+							"title": "Image tag",
+							"type": "string"
+						}
+					},
+					"title": "Etcd",
+					"type": "object"
+				},
+				"replicas": {
+					"title": "Number of nodes",
+					"type": "integer"
+				}
+			},
+			"title": "Control plane",
+			"type": "object"
+		},
+		"connectivity": {
+			"properties": {
+				"network": {
+					"properties": {
+						"allowAllEgress": {
+							"default": false,
+							"title": "Allow all egress",
+							"type": "boolean"
+						},
+						"containerRegistries": {
+							"type": "object",
+							"title": "Container registries",
+							"description": "Endpoints and credentials configuration for container registries.",
+							"additionalProperties": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"required": [
+										"endpoint"
+									],
+									"additionalProperties": false,
+									"properties": {
+										"credentials": {
+											"type": "object",
+											"title": "Credentials",
+											"description": "Credentials for the endpoint.",
+											"additionalProperties": false,
+											"properties": {
+												"auth": {
+													"type": "string",
+													"title": "Auth",
+													"description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
+												},
+												"identitytoken": {
+													"type": "string",
+													"title": "Identity token",
+													"description": "Used to authenticate the user and obtain an access token for the registry."
+												},
+												"password": {
+													"type": "string",
+													"title": "Password",
+													"description": "Used to authenticate for the registry with username/password."
+												},
+												"username": {
+													"type": "string",
+													"title": "Username",
+													"description": "Used to authenticate for the registry with username/password."
+												}
+											}
+										},
+										"endpoint": {
+											"type": "string",
+											"title": "Endpoint",
+											"description": "Endpoint for the container registry."
+										}
+									}
+								}
+							},
+							"default": {}
+						},
+						"controlPlaneEndpoint": {
+							"description": "Kubernetes API configuration.",
+							"properties": {
+								"host": {
+									"title": "Host",
+									"description": "IP for access to the Kubernetes API.",
+									"type": "string"
+								},
+								"port": {
+									"title": "Port number",
+									"description": "Port for access to the Kubernetes API.",
+									"type": "integer"
+								},
+								"ipPoolName": {
+									"title": "Ip Pool Name",
+									"description": "Ip for control plane will be drawn from this InClusterIPPool resource.",
+									"type": "string",
+									"pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+									"default": "wc-cp-ips"
+								}
+							},
+							"title": "Endpoint",
+							"type": "object"
+						},
+						"pods": {
+							"properties": {
+								"cidrBlocks": {
+									"$ref": "#/$defs/cidrBlocks",
+									"default": "10.244.0.0/16",
+									"title": "Pod subnets"
+								}
+							},
+							"required": [
+								"cidrBlocks"
+							],
+							"title": "Pods",
+							"type": "object"
+						},
+						"services": {
+							"properties": {
+								"cidrBlocks": {
+									"$ref": "#/$defs/cidrBlocks",
+									"default": "172.31.0.0/16",
+									"title": "Service subnets"
+								}
+							},
+							"required": [
+								"cidrBlocks"
+							],
+							"title": "Services",
+							"type": "object"
+						},
+						"loadBalancers": {
+							"properties": {
+								"cidrBlocks": {
+									"$ref": "#/$defs/cidrBlocks",
+									"title": "Load Balancer subnets"
+								}
+							},
+							"required": [
+								"cidrBlocks"
+							],
+							"title": "Load balancers",
+							"type": "object"
+						}
+					},
+					"required": [
+						"pods",
+						"services",
+						"loadBalancers"
+					],
+					"title": "Network",
+					"type": "object"
+				}
+			},
+			"required": [
+				"network"
+			],
+			"title": "Connectivity",
+			"type": "object"
+		},
+		"internal": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"sandboxContainerImage": {
+					"type": "object",
+					"title": "Sandbox Container image",
+					"properties": {
+						"name": {
+							"type": "string",
+							"title": "Repository",
+							"default": "tkg/pause"
+						},
+						"registry": {
+							"type": "string",
+							"title": "Registry",
+							"default": "projects.registry.vmware.com/"
+						},
+						"tag": {
+							"type": "string",
+							"title": "Tag",
+							"default": "3.7"
+						}
+					}
+				}
+			}
+		},
+		"kubeadm": {
+			"properties": {
+				"users": {
+					"items": {
+						"properties": {
+							"authorizedKeys": {
+								"items": {
+									"title": "Key",
+									"type": "string"
+								},
+								"title": "Authorized keys",
+								"type": "array"
+							},
+							"name": {
+								"title": "Name",
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"title": "Users",
+					"type": "array"
+				}
+			},
+			"title": "Kubeadm",
+			"type": [
+				"null",
+				"object"
+			]
+		},
+		"kubectlImage": {
+			"description": "Used by cluster-shared library chart to configure coredns in-cluster.",
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"registry": {
+					"type": "string"
+				},
+				"tag": {
+					"type": "string"
+				}
+			},
+			"title": "Kubectl image",
+			"type": "object"
+		},
+		"organization": {
+			"title": "Organization",
+			"type": "string"
+		},
+		"template": {
+			"description": "Provisioning options for node templates.",
+			"properties": {
+				"cloneMode": {
+					"description": "Method used to clone template image.",
+					"title": "Clone mode",
+					"type": "string"
+				},
+				"diskGiB": {
+					"description": "Node disk size in GB. Must be at least as large as the source image.",
+					"title": "Disk size (GB)",
+					"type": "integer"
+				},
+				"folder": {
+					"description": "VSphere folder to deploy instances in. Must already exist.",
+					"title": "Folder",
+					"type": "string"
+				},
+				"memoryMiB": {
+					"description": "Node memory allocation in MB.",
+					"title": "Memory (MB)",
+					"type": "integer"
+				},
+				"networkName": {
+					"description": "Segment name to attach nodes to. Must already exist.",
+					"title": "Segment name",
+					"type": "string"
+				},
+				"numCPUs": {
+					"description": "Number of CPUs to assign per node.",
+					"title": "CPU cores",
+					"type": "integer"
+				},
+				"resourcePool": {
+					"description": "Resource pool to allocate nodes from. Must already exist.",
+					"title": "Resource pool",
+					"type": "string"
+				},
+				"storagePolicyName": {
+					"description": "Storage policy to use. If specified, it must already exist.",
+					"title": "Storage policy",
+					"type": "string"
+				},
+				"templateName": {
+					"description": "Image template name to use for nodes.",
+					"title": "Name",
+					"type": "string"
+				}
+			},
+			"title": "Node template",
+			"type": "object"
+		},
+		"vcenter": {
+			"description": "Configuration for vSphere API access.",
+			"properties": {
+				"datacenter": {
+					"description": "Name of the datacenter to deploy nodes into.",
+					"title": "Datacenter",
+					"type": "string"
+				},
+				"datastore": {
+					"description": "Name of the datastore for node disk storage.",
+					"title": "Datastore",
+					"type": "string"
+				},
+				"server": {
+					"description": "URL of the VSphere API.",
+					"title": "Server",
+					"type": "string"
+				},
+				"username": {
+					"description": "Username for the VSphere API.",
+					"title": "Username",
+					"type": "string"
+				},
+				"password": {
+					"description": "Password for the VSphere API.",
+					"title": "Password",
+					"type": "string"
+				},
+				"thumbprint": {
+					"description": "TLS certificate signature of the VSphere API.",
+					"title": "Thumbprint",
+					"type": "string"
+				},
+				"region": {
+					"description": "Category name in VSphere for topology.kubernetes.io/region labels.",
+					"title": "Region",
+					"type": "string"
+				},
+				"zone": {
+					"description": "Category name in VSphere for topology.kubernetes.io/zone labels.",
+					"title": "Zone",
+					"type": "string"
+				}
+			},
+			"title": "VCenter",
+			"type": "object"
+		},
+		"worker": {
+			"properties": {
+				"replicas": {
+					"title": "Number of nodes",
+					"type": "integer"
+				}
+			},
+			"title": "Worker",
+			"type": "object"
+		}
+	},
+	"type": "object"
 }

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -123,6 +123,12 @@ connectivity:
 #       auth: ""
 #       identitytoken: ""
 
+internal:
+  sandboxContainerImage:
+    name: tkg/pause
+    registry: projects.registry.vmware.com/
+    tag: "3.7"
+
 # Class definitions for worker node pools or controle planes. The "name" of the class is the key of the object. Example:
 nodeClasses:
   # Provisioning options for node templates.

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -125,9 +125,9 @@ connectivity:
 
 internal:
   sandboxContainerImage:
-    name: tkg/pause
-    registry: projects.registry.vmware.com/
-    tag: "3.7"
+    name: giantswarm/pause
+    registry: quay.io
+    tag: "3.9"
 
 # Class definitions for worker node pools or controle planes. The "name" of the class is the key of the object. Example:
 nodeClasses:


### PR DESCRIPTION
This PR:

- Consolidate the full `config.toml` configuration file for containerd into a single file to address [#1737](https://github.com/giantswarm/roadmap/issues/1737)

@erkanerol as discussed in https://gigantic.slack.com/archives/C01BYMF6RN0/p1689847741604689?thread_ts=1689844311.988129&cid=C01BYMF6RN0 can you verify it when using the `credentials and mirrors` configurations ? the structure of values has not changed for those settings

<details>
  <summary>How to run CI</summary>

Comment on this PR with:

```
/run cluster-test-suites
```
</details>
