### PR TITLE
Bump cilium app version to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Consolidate containerd `config.toml` into single file to address [#1737](https://github.com/giantswarm/roadmap/issues/1737)
+- Bump `cilium` version to `0.10.0` 
 
 ## [0.6.1] - 2023-07-13
 

--- a/helm/cluster-vsphere/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/cilium-helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
   chart:
     spec:
       chart: cilium
-      version: 0.6.1
+      version: 0.10.0
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default
@@ -33,7 +33,7 @@ spec:
     ipam:
       mode: kubernetes
     k8sServiceHost: api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}
-    k8sServicePort: 6443
+    k8sServicePort: "6443"
     kubeProxyReplacement: strict
     hubble:
       relay:

--- a/helm/cluster-vsphere/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/cilium-helmrelease.yaml
@@ -38,6 +38,29 @@ spec:
     hubble:
       relay:
         enabled: true
+        tolerations:
+          - key: "node-role.kubernetes.io/master"
+            effect: "NoSchedule"
+            operator: "Exists"
+          - key: "node-role.kubernetes.io/control-plane"
+            effect: "NoSchedule"
+            operator: "Exists"
+          - key: "node.cloudprovider.kubernetes.io/uninitialized"
+            effect: "NoSchedule"
+            operator: "Equal"
+            value: "true"
+      ui:
+        tolerations:
+          - key: "node-role.kubernetes.io/master"
+            effect: "NoSchedule"
+            operator: "Exists"
+          - key: "node-role.kubernetes.io/control-plane"
+            effect: "NoSchedule"
+            operator: "Exists"
+          - key: "node.cloudprovider.kubernetes.io/uninitialized"
+            effect: "NoSchedule"
+            operator: "Equal"
+            value: "true"
 {{- if .Values.connectivity.network.allowAllEgress }}
     defaultPolicies:
       enabled: true


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27728

Conformance tests have failed with this error

```
[sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]
```

As far as I understand from [this](https://github.com/giantswarm/roadmap/issues/1346) issue, it is because of the cilium version. CAPZ passed the conformance tests and it has the newer version. This change is supposed to fix the conformance tests.

I applied the toleration changes in CAPVCD to this manifest too. See https://github.com/giantswarm/cluster-cloud-director/commit/bf00c740f80e2b910a182cd1ea0dfe0c0353cc35


<details>
  <summary>How to run CI</summary>

Comment on this PR with:

```
/run cluster-test-suites
```
</details>