### PR TITLE
add user nobody to root group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Consolidate containerd `config.toml` into single file to address [#1737](https://github.com/giantswarm/roadmap/issues/1737)
+- Add host OS user `nobody` to `root` group to enable node-exporter's `filesystem` collector to access the host filesystem.
 
 ## [0.6.1] - 2023-07-13
 

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -117,6 +117,7 @@ preKubeadmCommands:
   {{- end }}
 postKubeadmCommands:
 {{ include "sshPostKubeadmCommands" . }}
+- usermod -aG root nobody # required for node-exporter to access the host's filesystem
 {{- end -}}
 
 {{- define "hostsAndHostname" }}


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/27037

This PR:

- adds user  nobody  to group  root  to allow node-exporter to access the host's filesystem.

this aligns with CAPA.
