### PR TITLE
IPAM for service LB in WC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add IPv4 addresses management (ipam) for WC's `kube-vip-cloud-provider`. If the ipPool is specified, currently one IP is requested from it
+and is added to the end of the list for this controller. `kube-vip-cloud-provider` is part of our Service-lvl load balancer solution in WC and
+at least 1 public IP is always needed for the ingress controller to be able to expose its stuff.
+
 ## [0.7.1] - 2023-09-04
 
 ### Fixed

--- a/helm/cluster-vsphere/templates/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/cloud-provider-vsphere-helmrelease.yaml
@@ -10,7 +10,7 @@ metadata:
     giantswarm.io/service-priority: "{{ .Values.servicePriority }}"
     {{- include "labels.common" . | nindent 4 }}
 spec:
-  suspend: false # It can be unsuspended by the post-install/post-upgrade hook. Useful if we need to populate some fields later on.
+  suspend: {{ include "isIpamSvcLoadBalancerEnabled" $ }} # It is unsuspended by the post-install/post-upgrade hook.
   releaseName: cloud-provider-vsphere
   targetNamespace: kube-system
   storageNamespace: kube-system

--- a/helm/cluster-vsphere/templates/ipam/_ipam.tpl
+++ b/helm/cluster-vsphere/templates/ipam/_ipam.tpl
@@ -8,6 +8,15 @@
     {{- end }}
 {{- end }}
 
+{{- define "isIpamSvcLoadBalancerEnabled" -}}
+    {{- if and (.Values.connectivity.network.loadBalancers.ipPoolName) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1alpha1/IPAddressClaim") }}
+        {{- printf "true" -}}
+    {{ else }}
+        {{- printf "false" -}}
+    {{- end }}
+{{- end }}
+
+
 {{/*
     The cluster.x-k8s.io/cluster-name label must not be added to IPAddressClaim resource,
     because the cluster-api-ipam-provider-in-cluster controller is trying to be smart and
@@ -21,4 +30,30 @@
             {{- printf "%s" $value -}}
         {{- end }}
     {{- end }}
+{{- end }}
+
+
+{{- define "lbClaimName" -}}
+{{- include "resource.default.name" $ }}-svc-lb
+{{- end -}}
+
+
+{{- define "ipamJobContainerCommon" -}}
+image: "{{ .Values.kubectlImage.registry }}/{{ .Values.kubectlImage.name }}:{{ .Values.kubectlImage.tag }}"
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+resources:
+  requests:
+    memory: "64Mi"
+    cpu: "10m"
+  limits:
+    memory: "256Mi"
+    cpu: "100m"
 {{- end }}

--- a/helm/cluster-vsphere/templates/ipam/_ipam.tpl
+++ b/helm/cluster-vsphere/templates/ipam/_ipam.tpl
@@ -1,18 +1,20 @@
 {{/* vim: set filetype=mustache: */}}
 
-{{- define "isIpamEnabled" -}}
+{{- define "isIpamControlPlaneIPEnabled" -}}
     {{- if and (and (not .Values.connectivity.network.controlPlaneEndpoint.host) (.Values.connectivity.network.controlPlaneEndpoint.ipPoolName)) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1alpha1/IPAddressClaim") }}
         {{- printf "true" -}}
-    {{ else }}
-        {{- printf "false" -}}
     {{- end }}
 {{- end }}
 
 {{- define "isIpamSvcLoadBalancerEnabled" -}}
     {{- if and (.Values.connectivity.network.loadBalancers.ipPoolName) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1alpha1/IPAddressClaim") }}
         {{- printf "true" -}}
-    {{ else }}
-        {{- printf "false" -}}
+    {{- end }}
+{{- end }}
+
+{{- define "isIpamEnabled" -}}
+    {{- if or (include "isIpamControlPlaneIPEnabled" $) (include "isIpamSvcLoadBalancerEnabled" $) }}
+        {{- printf "true" -}}
     {{- end }}
 {{- end }}
 

--- a/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
+++ b/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
@@ -128,10 +128,9 @@ spec:
               done
               echo "Got the IP: ${new_ip}"
               # patch the cloud-provider-vsphere-helmrelease
-              # all_cidrs={{ join "," .Values.connectivity.network.loadBalancers.cidrBlocks }}
               {{- if .Values.connectivity.network.loadBalancers.cidrBlocks }}
               new_ip="${new_ip},{{ join "," .Values.connectivity.network.loadBalancers.cidrBlocks }}"
-              {{- end -}}
+              {{- end }}
               kubectl patch helmrelease -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }}-cloud-provider-vsphere --type=merge -p '{"spec":{"suspend":false,"values":{"global": {"kube-vip-cloud-provider": {"cidrGlobal": "'${new_ip}'"}}}}}'
 {{- end }}
       containers:

--- a/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
+++ b/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
@@ -131,7 +131,7 @@ spec:
               {{- if .Values.connectivity.network.loadBalancers.cidrBlocks }}
               new_ip="${new_ip},{{ join "," .Values.connectivity.network.loadBalancers.cidrBlocks }}"
               {{- end }}
-              kubectl patch helmrelease -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }}-cloud-provider-vsphere --type=merge -p '{"spec":{"suspend":false,"values":{"global": {"kube-vip-cloud-provider": {"cidrGlobal": "'${new_ip}'"}}}}}'
+              kubectl patch helmrelease -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }}-cloud-provider-vsphere --type=merge -p '{"spec":{"suspend":false,"values":{"kube-vip-cloud-provider": {"cidrGlobal": "'${new_ip}'"}}}}'
 {{- end }}
       containers:
         - name: resume-cluster

--- a/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
+++ b/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
@@ -111,7 +111,7 @@ spec:
 
 {{- end }}
 {{- if (include "isIpamSvcLoadBalancerEnabled" $) }}
-        - name: get-ip-for-control-plane
+        - name: get-ip-for-svc-lb
           {{- include "ipamJobContainerCommon" . | nindent 10 }}
           command:
             - "/bin/bash"

--- a/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
+++ b/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq (include "isIpamEnabled" $) "true") (eq (include "isIpamSvcLoadBalancerEnabled" $) "true") -}}
+{{- if (include "isIpamEnabled" $) -}}
 # Because IP for control plane of new workload cluster is not known at the time of cluster creation
 # we use a post-install/post-upgrade hook Job to assign the IP from IPAddress CR.
 # This IPAddress CR should be created by cluster-api-ipam-provider-in-cluster controller as a
@@ -46,7 +46,7 @@ spec:
             - "/bin/bash"
             - "-xc"
             - kubectl patch cluster -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }} --type=merge -p '{"spec":{"paused":true}}'
-{{- if eq (include "isIpamSvcLoadBalancerEnabled" $) "true" }}
+{{- if (include "isIpamSvcLoadBalancerEnabled" $) }}
             - kubectl patch helmrelease -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }}-cloud-provider-vsphere --type=merge -p '{"spec":{"suspend":true}}'
 {{- end }}
 ---
@@ -76,7 +76,7 @@ spec:
         runAsUser: {{ include "securityContext.runAsUser" $ }}
         runAsGroup: {{ include "securityContext.runAsGroup" $ }}
       initContainers:
-{{- if eq (include "isIpamEnabled" $) "true" }}
+{{- if (include "isIpamControlPlaneIPEnabled" $) }}
         - name: get-ip-for-control-plane
           {{- include "ipamJobContainerCommon" . | nindent 10 }}
           command:
@@ -110,7 +110,7 @@ spec:
               kubectl patch secret -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }}-kubevip-pod --type=merge -p '{"data": {"content": "'${encoded}'"}}'
 
 {{- end }}
-{{- if eq (include "isIpamSvcLoadBalancerEnabled" $) "true" }}
+{{- if (include "isIpamSvcLoadBalancerEnabled" $) }}
         - name: get-ip-for-control-plane
           {{- include "ipamJobContainerCommon" . | nindent 10 }}
           command:

--- a/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
+++ b/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "isIpamEnabled" $) "true" -}}
+{{- if or (eq (include "isIpamEnabled" $) "true") (eq (include "isIpamSvcLoadBalancerEnabled" $) "true") -}}
 # Because IP for control plane of new workload cluster is not known at the time of cluster creation
 # we use a post-install/post-upgrade hook Job to assign the IP from IPAddress CR.
 # This IPAddress CR should be created by cluster-api-ipam-provider-in-cluster controller as a
@@ -8,7 +8,10 @@
 #   - static pod definition for kubevip (.spec.containers.env[vip_address])
 #   - kubeadmcontrolplane.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.certSANs[0]
 #
-# In case of upgrade, the Cluster CR is first paused, then IP is assigned and then the cluster is unpaused
+# In case of upgrade, the Cluster CR is first paused, then IP is assigned and then the cluster is unpaused.
+# 
+# If `isIpamSvcLoadBalancerEnabled`, this job also allocates a new free IP for kubevip Service Load Balancer running in WC. 
+# This is passed as a config option in HelmRelease -> helm release needs to be suspended first, updated and resumed 
 #
 # every resource in this file has "helm.sh/hook-weight": "0"
 apiVersion: batch/v1
@@ -38,21 +41,14 @@ spec:
         runAsGroup: {{ include "securityContext.runAsGroup" $ }}
       containers:
         - name: pre-upgrade-job
-          image: "{{ .Values.kubectlImage.registry }}/{{ .Values.kubectlImage.name }}:{{ .Values.kubectlImage.tag }}"
+          {{- include "ipamJobContainerCommon" . | nindent 10 }}
           command:
-            - "/bin/sh"
+            - "/bin/bash"
             - "-xc"
-            - |
-              kubectl patch cluster -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }} --type=merge -p '{"spec":{"paused":true}}'
-          securityContext:
-            readOnlyRootFilesystem: true
-          resources:
-            requests:
-              memory: "64Mi"
-              cpu: "10m"
-            limits:
-              memory: "256Mi"
-              cpu: "100m"
+            - kubectl patch cluster -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }} --type=merge -p '{"spec":{"paused":true}}'
+{{- if eq (include "isIpamSvcLoadBalancerEnabled" $) "true" }}
+            - kubectl patch helmrelease -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }}-cloud-provider-vsphere --type=merge -p '{"spec":{"suspend":true}}'
+{{- end }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -79,9 +75,10 @@ spec:
       securityContext:
         runAsUser: {{ include "securityContext.runAsUser" $ }}
         runAsGroup: {{ include "securityContext.runAsGroup" $ }}
-      containers:
-        - name: post-install-job
-          image: "{{ .Values.kubectlImage.registry }}/{{ .Values.kubectlImage.name }}:{{ .Values.kubectlImage.tag }}"
+      initContainers:
+{{- if eq (include "isIpamEnabled" $) "true" }}
+        - name: get-ip-for-control-plane
+          {{- include "ipamJobContainerCommon" . | nindent 10 }}
           command:
             - "/bin/bash"
             - "-c"
@@ -112,16 +109,43 @@ spec:
                 | base64 -w 0)
               kubectl patch secret -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }}-kubevip-pod --type=merge -p '{"data": {"content": "'${encoded}'"}}'
 
-              echo "New IP has been assigned, upausing the Cluster '{{ include "resource.default.name" $ }}' resource.."
+{{- end }}
+{{- if eq (include "isIpamSvcLoadBalancerEnabled" $) "true" }}
+        - name: get-ip-for-control-plane
+          {{- include "ipamJobContainerCommon" . | nindent 10 }}
+          command:
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -o errexit
+              set -o pipefail
+              set -o nounset
+              new_ip=""
+              while [ -z "${new_ip}" ] ; do
+                echo "waiting for a free IP address.."
+                new_ip="$(kubectl get ipaddress -n {{ $.Release.Namespace }} {{ include "lbClaimName" $ }} -o 'jsonpath={.spec.address}')/32"
+                sleep 2
+              done
+              echo "Got the IP: ${new_ip}"
+              # patch the cloud-provider-vsphere-helmrelease
+              # all_cidrs={{ join "," .Values.connectivity.network.loadBalancers.cidrBlocks }}
+              {{- if .Values.connectivity.network.loadBalancers.cidrBlocks }}
+              new_ip="${new_ip},{{ join "," .Values.connectivity.network.loadBalancers.cidrBlocks }}"
+              {{- end -}}
+              kubectl patch helmrelease -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }}-cloud-provider-vsphere --type=merge -p '{"spec":{"suspend":false,"values":{"global": {"kube-vip-cloud-provider": {"cidrGlobal": "'${new_ip}'"}}}}}'
+{{- end }}
+      containers:
+        - name: resume-cluster
+          {{- include "ipamJobContainerCommon" . | nindent 10 }}
+          command:
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -o errexit
+              set -o pipefail
+              set -o nounset
+              echo "New IPs have been assigned, upausing the Cluster '{{ include "resource.default.name" $ }}' resource.."
+              kubectl get ipaddress -n {{ $.Release.Namespace }}
               kubectl patch cluster -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }} --type=merge -p '{"spec":{"paused":false}}'
-          securityContext:
-            readOnlyRootFilesystem: true
-          resources:
-            requests:
-              memory: "64Mi"
-              cpu: "10m"
-            limits:
-              memory: "256Mi"
-              cpu: "100m"
 ---
-{{- end -}}
+{{- end }}

--- a/helm/cluster-vsphere/templates/ipam/ipAddressClaim.yaml
+++ b/helm/cluster-vsphere/templates/ipam/ipAddressClaim.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "isIpamEnabled" $) "true" -}}
+{{- if (include "isIpamControlPlaneIPEnabled" $) -}}
 apiVersion: ipam.cluster.x-k8s.io/v1alpha1
 kind: IPAddressClaim
 metadata:

--- a/helm/cluster-vsphere/templates/ipam/ipAddressClaimLB.yaml
+++ b/helm/cluster-vsphere/templates/ipam/ipAddressClaimLB.yaml
@@ -1,13 +1,13 @@
-{{- if eq (include "isIpamEnabled" $) "true" -}}
+{{- if eq (include "isIpamSvcLoadBalancerEnabled" $) "true" -}}
 apiVersion: ipam.cluster.x-k8s.io/v1alpha1
 kind: IPAddressClaim
 metadata:
-  name: {{ include "resource.default.name" $ }}
+  name: {{ include "lbClaimName" $ }}
   labels:
     {{- include "ipamLabels" $ | nindent 4 }}
 spec:
   poolRef:
     apiGroup: ipam.cluster.x-k8s.io
     kind: GlobalInClusterIPPool
-    name: {{ .Values.connectivity.network.controlPlaneEndpoint.ipPoolName }}
+    name: {{ .Values.connectivity.network.loadBalancers.ipPoolName }}
 {{- end }}

--- a/helm/cluster-vsphere/templates/ipam/ipAddressClaimLB.yaml
+++ b/helm/cluster-vsphere/templates/ipam/ipAddressClaimLB.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "isIpamSvcLoadBalancerEnabled" $) "true" -}}
+{{- if (include "isIpamSvcLoadBalancerEnabled" $) -}}
 apiVersion: ipam.cluster.x-k8s.io/v1alpha1
 kind: IPAddressClaim
 metadata:

--- a/helm/cluster-vsphere/templates/ipam/rbac.yaml
+++ b/helm/cluster-vsphere/templates/ipam/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "isIpamEnabled" $) "true" -}}
+{{- if or (eq (include "isIpamEnabled" $) "true") (eq (include "isIpamSvcLoadBalancerEnabled" $) "true") -}}
 # every resource in this file has "helm.sh/hook-weight": "-1" or "-2"
 apiVersion: v1
 kind: ServiceAccount
@@ -34,7 +34,7 @@ rules:
     verbs: ["get", "patch"]
   - apiGroups: ["ipam.cluster.x-k8s.io"]
     resources: ["ipaddresses"]
-    resourceNames: ["{{ include "resource.default.name" $ }}"]
+    resourceNames: ["{{ include "resource.default.name" $ }}", "{{ include "lbClaimName" $ }}"]
     verbs: ["get", "list"]
   - apiGroups: ["controlplane.cluster.x-k8s.io"]
     resources: ["kubeadmcontrolplanes"]
@@ -44,6 +44,12 @@ rules:
     resources: ["secrets"]
     resourceNames: ["{{ include "resource.default.name" $ }}-kubevip-pod"]
     verbs: ["get", "patch"]
+{{- if eq (include "isIpamSvcLoadBalancerEnabled" $) "true" }}
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    resourceNames: ["{{ include "resource.default.name" $ }}-cloud-provider-vsphere"]
+    verbs: ["get", "patch"]
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -65,4 +71,4 @@ roleRef:
   name: "{{ include "resource.default.name" $ }}-update-values-hook"
   apiGroup: rbac.authorization.k8s.io
 ---
-{{- end -}}
+{{- end }}

--- a/helm/cluster-vsphere/templates/ipam/rbac.yaml
+++ b/helm/cluster-vsphere/templates/ipam/rbac.yaml
@@ -34,7 +34,6 @@ rules:
     verbs: ["get", "patch"]
   - apiGroups: ["ipam.cluster.x-k8s.io"]
     resources: ["ipaddresses"]
-    resourceNames: ["{{ include "resource.default.name" $ }}", "{{ include "lbClaimName" $ }}"]
     verbs: ["get", "list"]
   - apiGroups: ["controlplane.cluster.x-k8s.io"]
     resources: ["kubeadmcontrolplanes"]

--- a/helm/cluster-vsphere/templates/ipam/rbac.yaml
+++ b/helm/cluster-vsphere/templates/ipam/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq (include "isIpamEnabled" $) "true") (eq (include "isIpamSvcLoadBalancerEnabled" $) "true") -}}
+{{- if (include "isIpamEnabled" $) -}}
 # every resource in this file has "helm.sh/hook-weight": "-1" or "-2"
 apiVersion: v1
 kind: ServiceAccount
@@ -44,7 +44,7 @@ rules:
     resources: ["secrets"]
     resourceNames: ["{{ include "resource.default.name" $ }}-kubevip-pod"]
     verbs: ["get", "patch"]
-{{- if eq (include "isIpamSvcLoadBalancerEnabled" $) "true" }}
+{{- if (include "isIpamSvcLoadBalancerEnabled" $) }}
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: ["helmreleases"]
     resourceNames: ["{{ include "resource.default.name" $ }}-cloud-provider-vsphere"]

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -10,9 +10,8 @@
 				],
 				"type": "string"
 			},
-			"minItems": 1,
-			"maxItems": 1,
-			"type": "array"
+			"type": "array",
+			"minItems": 1
 		}
 	},
 	"properties": {
@@ -195,14 +194,27 @@
 							"type": "object"
 						},
 						"loadBalancers": {
-							"properties": {
-								"cidrBlocks": {
-									"$ref": "#/$defs/cidrBlocks",
-									"title": "Load Balancer subnets"
+							"anyOf": [
+								{
+									"properties": {
+										"cidrBlocks": {
+											"$ref": "#/$defs/cidrBlocks",
+											"title": "Load Balancer subnets"
+										}
+									},
+									"required": ["cidrBlocks"]
+								},
+								{
+									"properties": {
+										"ipPoolName": {
+											"title": "Ip Pool Name",
+											"description": "Ip for Service LB running in WC will be drawn from this InClusterIPPool resource.",
+											"type": "string",
+											"pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+										}
+									},
+									"required": ["ipPoolName"]
 								}
-							},
-							"required": [
-								"cidrBlocks"
 							],
 							"title": "Load balancers",
 							"type": "object"

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -156,7 +156,7 @@
 								},
 								"ipPoolName": {
 									"title": "Ip Pool Name",
-									"description": "Ip for control plane will be drawn from this InClusterIPPool resource.",
+									"description": "Ip for control plane will be drawn from this GlobalInClusterIPPool resource.",
 									"type": "string",
 									"pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
 									"default": "wc-cp-ips"
@@ -208,7 +208,7 @@
 									"properties": {
 										"ipPoolName": {
 											"title": "Ip Pool Name",
-											"description": "Ip for Service LB running in WC will be drawn from this InClusterIPPool resource.",
+											"description": "Ip for Service LB running in WC will be drawn from this GlobalInClusterIPPool resource.",
 											"type": "string",
 											"pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 										}

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -102,9 +102,10 @@ connectivity:
     controlPlaneEndpoint:
       host: ""   # [string] Manually select an IP for kube API. "" for auto selection from the ipPoolName pool.
       port: 6443
-      ipPoolName: "wc-cp-ips"  # [string] Ip for control plane will be drawn from this InClusterIPPool.
+      ipPoolName: "wc-cp-ips"  # IP address for control plane will be drawn from this InClusterIPPool.
     loadBalancers:
       cidrBlocks: []
+      ipPoolName: ""  # If this field is not empty, we will allocate one IP from this InClusterIPPool and add it to loadBalancers.cidrBlocks with '/32' at the end
     pods:
       cidrBlocks:
       - "10.244.0.0/16"

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -102,10 +102,10 @@ connectivity:
     controlPlaneEndpoint:
       host: ""   # [string] Manually select an IP for kube API. "" for auto selection from the ipPoolName pool.
       port: 6443
-      ipPoolName: "wc-cp-ips"  # IP address for control plane will be drawn from this InClusterIPPool.
+      ipPoolName: "wc-cp-ips"  # IP address for control plane will be drawn from this GlobalInClusterIPPool.
     loadBalancers:
       cidrBlocks: []
-      ipPoolName: ""  # If this field is not empty, we will allocate one IP from this InClusterIPPool and add it to loadBalancers.cidrBlocks with '/32' at the end
+      ipPoolName: ""  # If this field is not empty, we will allocate one IP from this GlobalInClusterIPPool and add it to loadBalancers.cidrBlocks with '/32' at the end
     pods:
       cidrBlocks:
       - "10.244.0.0/16"


### PR DESCRIPTION
issue: https://github.com/giantswarm/giantswarm/issues/28655

This pr:
- adds a way to auto-assign an IP for service LB running in WC (kube-vip).

Kube-vip cloud provider watches for services of type LB and assigns a new ip for them from a range. This range is configured in WC using a configmap called `kubevip@kube-system`. 

However, we need to populate the content of the configmap upfront during the cluster creation (we currently ship kube-vip and kubevip-cloud-provider as sub-chart in our "CPI bundle") and more importantly we need to somewhere keep track of what IPs have been used. Each WC requires at least 1 IP to work properly, because the ingress of nginx controller needs to be exposed using this mechanism. Then other stuff, like grafana, dex, anthena, prometheus, happa can be exposed through the ingress mechanism.

This PR in short, [creates](https://github.com/giantswarm/cluster-vsphere/pull/102/files#diff-1ab6ee325cf8ccec9347369db06e5e11723e4e4ed45544a8b7f65d7522e1ff1e) the `IPAddressClaim` resource similarly as for CP's IP if the `.networking.loadBalancers.ipPoolName` helm option is not empty. Then waits for this claim to be served by the ipam controller, updates the value for `CPI bundle` helm chart and only then resumes the Cluster CR so that the reconciliation can actually start.


tested end-end here: https://asciinema.org/a/618186
