### PR TITLE
When IP was not obtained it failed after first attempt 

### DIFF
--- a/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
+++ b/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
@@ -89,7 +89,7 @@ spec:
               new_ip=""
               while [ -z "${new_ip}" ] ; do
                 echo "waiting for a free IP address.."
-                new_ip=$(kubectl get ipaddress -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }} -o 'jsonpath={.spec.address}')
+                new_ip=$(kubectl get ipaddress -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }} -o 'jsonpath={.spec.address}') || true
                 sleep 2
               done
               echo "Got the IP: ${new_ip}"
@@ -123,10 +123,11 @@ spec:
               new_ip=""
               while [ -z "${new_ip}" ] ; do
                 echo "waiting for a free IP address.."
-                new_ip="$(kubectl get ipaddress -n {{ $.Release.Namespace }} {{ include "lbClaimName" $ }} -o 'jsonpath={.spec.address}')/32"
+                new_ip="$(kubectl get ipaddress -n {{ $.Release.Namespace }} {{ include "lbClaimName" $ }} -o 'jsonpath={.spec.address}')" || true
                 sleep 2
               done
               echo "Got the IP: ${new_ip}"
+              new_ip=${new_ip}/32"
               # patch the cloud-provider-vsphere-helmrelease
               {{- if .Values.connectivity.network.loadBalancers.cidrBlocks }}
               new_ip="${new_ip},{{ join "," .Values.connectivity.network.loadBalancers.cidrBlocks }}"


### PR DESCRIPTION
because of the 'set -o errexit'


```
λ kubectl logs -f flatcar12-update-values-hook-kx8zw -n org-giantswarm -c get-ip-for-control-plane                                                                                                                        17s ○ gcapeverde-admin@gcapeverde
waiting for a free IP address..
Error from server (NotFound): ipaddresses.ipam.cluster.x-k8s.io "flatcar12" not found
```
instead of looping and waiting. This happens when there are no more free ip in the pool.