### PR TITLE
Bump cilium and coredns versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `cilium` to `0.17.0`.
+- Bump `coredns` to `1.19.0`.
+- Enable renovate for `cilium` and `coredns`.
+
+
 ## [0.9.0] - 2023-11-08
 
 ### Changed

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -221,10 +221,23 @@ ignition:
             After=coreos-metadata.service
             [Service]
             Type=oneshot
+            RemainAfterExit=yes
             EnvironmentFile=/run/metadata/coreos
             ExecStart=/opt/set-hostname
             [Install]
             WantedBy=multi-user.target
+        - name: ethtool-segmentation.service
+          enabled: true
+          contents: |
+            [Unit]
+            After=network.target
+            [Service]
+            Type=oneshot
+            RemainAfterExit=yes
+            ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-csum-segmentation off
+            ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-segmentation off
+            [Install]
+            WantedBy=default.target
         - name: kubeadm.service
           enabled: true
           dropins:

--- a/helm/cluster-vsphere/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/cilium-helmrelease.yaml
@@ -16,7 +16,9 @@ spec:
   chart:
     spec:
       chart: cilium
-      version: 0.10.0
+      # used by renovate
+      # repo: giantswarm/cilium-app
+      version: 0.17.0
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default
@@ -72,3 +74,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
 {{- end }}
+    extraPolicies:
+      allowEgressToCoreDNS:
+        enabled: true
+

--- a/helm/cluster-vsphere/templates/coredns-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/coredns-helmrelease.yaml
@@ -14,7 +14,9 @@ spec:
   chart:
     spec:
       chart: coredns-app
-      version: 1.16.0
+      # used by renovate
+      # repo: giantswarm/coredns-app
+      version: 1.19.0
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -91,6 +91,8 @@ spec:
         extraArgs:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
           bind-address: "0.0.0.0"
+      networking:
+        serviceSubnet: {{ join "," .Values.connectivity.network.services.cidrBlocks }}
     {{- include "sshUsers" . | nindent 4 }}
     {{- include "ignitionSpec" . | nindent 4 }}
     initConfiguration:


### PR DESCRIPTION
Allign cilium&coredns version with cluster-aws to check if it fixes cert-manager installation issues.

<details>
  <summary>How to run CI</summary>

Comment on this PR with:

```
/run cluster-test-suites
```
</details>