### PR TITLE
Add systemd unit that will run ethtool to turn off 'hardware segmentation offload'

### DIFF
--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -221,10 +221,23 @@ ignition:
             After=coreos-metadata.service
             [Service]
             Type=oneshot
+            RemainAfterExit=yes
             EnvironmentFile=/run/metadata/coreos
             ExecStart=/opt/set-hostname
             [Install]
             WantedBy=multi-user.target
+        - name: ethtool-segmentation.service
+          enabled: true
+          contents: |
+            [Unit]
+            After=network.target
+            [Service]
+            Type=oneshot
+            RemainAfterExit=yes
+            ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-csum-segmentation off
+            ExecStart=/usr/sbin/ethtool -K ens192 tx-udp_tnl-segmentation off
+            [Install]
+            WantedBy=default.target
         - name: kubeadm.service
           enabled: true
           dropins:


### PR DESCRIPTION
Needed by cilium to perform the health checks successfully. echo `all the fame` > `@erkanerol` :)

context:
- https://gigantic.slack.com/archives/C01BYMF6RN0/p1699633642085999
- https://github.com/cilium/cilium/issues/21801

