### PR TITLE
fix quotes + use --ignore-not-found

### DIFF
--- a/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
+++ b/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
@@ -89,7 +89,7 @@ spec:
               new_ip=""
               while [ -z "${new_ip}" ] ; do
                 echo "waiting for a free IP address.."
-                new_ip=$(kubectl get ipaddress -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }} -o 'jsonpath={.spec.address}') || true
+                new_ip=$(kubectl get ipaddress --ignore-not-found -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }} -o 'jsonpath={.spec.address}')
                 sleep 2
               done
               echo "Got the IP: ${new_ip}"
@@ -123,7 +123,7 @@ spec:
               new_ip=""
               while [ -z "${new_ip}" ] ; do
                 echo "waiting for a free IP address.."
-                new_ip="$(kubectl get ipaddress -n {{ $.Release.Namespace }} {{ include "lbClaimName" $ }} -o 'jsonpath={.spec.address}')" || true
+                new_ip=$(kubectl get ipaddress --ignore-not-found -n {{ $.Release.Namespace }} {{ include "lbClaimName" $ }} -o 'jsonpath={.spec.address}')
                 sleep 2
               done
               echo "Got the IP: ${new_ip}"


### PR DESCRIPTION
```
➜ k logs t-q2ec0n3-update-values-hook-qg5mb -c get-ip-for-svc-lb
,waiting for a free IP address..
Got the IP: 10.10.222.245
/bin/bash: -c: line 12: unexpected EOF while looking for matching `"'
```