### PR TITLE
Allow disabling PSPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `cilium` to `0.17.0`.
 - Bump `coredns` to `1.19.0`.
 - Enable renovate for `cilium` and `coredns`.
+- Disable PSPs for helm released based on installed k8s version.
 
 
 ## [0.9.0] - 2023-11-08

--- a/helm/cluster-vsphere/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/cilium-helmrelease.yaml
@@ -32,6 +32,11 @@ spec:
   # Default values
   # https://github.com/giantswarm/cilium-app/blob/main/helm/cilium/values.yaml
   values:
+    {{- if semverCompare ">=1.25" .Values.cluster.kubernetesVersion }}
+    global:
+      podSecurityStandards:
+        enforced: true
+    {{- end }}
     ipam:
       mode: kubernetes
     k8sServiceHost: api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}

--- a/helm/cluster-vsphere/templates/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/cloud-provider-vsphere-helmrelease.yaml
@@ -42,6 +42,10 @@ spec:
       targetPath: "global.config.password"
   values:
     global:
+      {{- if semverCompare ">=1.25" .Values.cluster.kubernetesVersion }}
+      podSecurityStandards:
+        enforced: true
+      {{- end }}
       config:
         enabled: true
         clusterId: {{ include "resource.default.name" $ }}

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -1,9 +1,9 @@
 apiServer:
   enableAdmissionPlugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"
-  featureGates: "TTLAfterFinished=true"
+  featureGates: ""
   certSANs: []
 controllerManager:
-  featureGates: "ExpandPersistentVolumes=true,TTLAfterFinished=true"
+  featureGates: "ExpandPersistentVolumes=true"
 
 clusterDescription: ""  # Cluster description used in metadata.
 organization: ""  # The organization which owns this cluster.


### PR DESCRIPTION
Otherwise Cilium helmrelease fails to install on `k8s@1.25`


note: I'd add this here in the transition period and remove it later, once the flags are true for all the apps (imho)

<details>
  <summary>How to run CI</summary>

Comment on this PR with:

```
/run cluster-test-suites
```
</details>