### PR TITLE
Bump kubevip to new version + consuming our own retagged images

### DIFF
--- a/helm/cluster-vsphere/templates/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/cloud-provider-vsphere-helmrelease.yaml
@@ -52,6 +52,12 @@ spec:
         thumbprint: "{{ .Values.vcenter.thumbprint }}"
     kube-vip-cloud-provider:
       cidrGlobal: '{{ join "," .Values.connectivity.network.loadBalancers.cidrBlocks }}'
+      image:
+        repository: docker.io/giantswarm/kube-vip-cloud-provider
+        tag: v0.0.4
     kube-vip:
       env:
         vip_interface: "ens192"
+      image:
+        repository: docker.io/giantswarm/kube-vip
+        tag: v0.6.3

--- a/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
+++ b/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
@@ -21,7 +21,7 @@ stringData:
         - name: svc_enable
           value: "false"
         - name: prometheus_server
-          value: "2113"
+          value: ":2113"
         - name: vip_arp
           value: "true"
         - name: vip_leaderelection

--- a/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
+++ b/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
@@ -9,14 +9,19 @@ stringData:
     apiVersion: v1
     kind: Pod
     metadata:
-      creationTimestamp: null
       name: kube-vip
       namespace: kube-system
     spec:
       containers:
       - args:
-        - start
+        - manager
         env:
+        - name: cp_enable
+          value: "true"
+        - name: svc_enable
+          value: "false"
+        - name: prometheus_server
+          value: "2113"
         - name: vip_arp
           value: "true"
         - name: vip_leaderelection
@@ -31,7 +36,7 @@ stringData:
           value: "10"
         - name: vip_retryperiod
           value: "2"
-        image: ghcr.io/kube-vip/kube-vip:v0.3.5
+        image: docker.io/giantswarm/kube-vip:v0.6.3
         imagePullPolicy: IfNotPresent
         name: kube-vip
         resources: {}
@@ -43,6 +48,10 @@ stringData:
         volumeMounts:
         - mountPath: /etc/kubernetes/admin.conf
           name: kubeconfig
+      hostAliases:
+      - hostnames:
+        - kubernetes
+        ip: 127.0.0.1
       hostNetwork: true
       volumes:
       - hostPath:


### PR DESCRIPTION
the host alias record for the static kubevip pod had to be added to workaround https://github.com/kube-vip/kube-vip/issues/287

otherwise the pod was not starting:
```
E1124 11:23:45.545715       1 leaderelection.go:327] error retrieving resource lock kube-system/plndr-cp-lock: Get "https://kubernetes:6443/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/plndr-cp-lock": dial tcp: lookup kubernetes on 10.10.223.5:53: no such host
```

Another required change is the prometheus port. The old version didn't ship the prom exporter so it worked, but new ones do and the default is `2112`. We deploy 2 flavors of kubevips:
 1) for CPs (having the `cp_enable=true && svc_enable=false`) 
 1) for all the nodes (having `svc_enable=true && cp_enable=false`)

This means that on CP there will be two pods of kubevip running -> port collision so we need to shift the port of prom exporter

Another breaking change was `s/start/manager/g`


With this change in, I was able to create a new WC, it had accessible api-server and it was possible to expose a service using public using the kubevip.