### PR TITLE
Remove TTLAfterFinished for 1.25 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove `TTLAfterFinished` flag for Kubernetes 1.25 compatibility (enabled by default).
+
 ## [0.9.2] - 2023-11-15
 
 ## [0.9.1] - 2023-11-15

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -44,7 +44,7 @@
 					"type": "string"
 				},
 				"featureGates": {
-					"default": "TTLAfterFinished=true",
+					"default": "",
 					"description": "Enabled feature gates, as a comma-separated list.",
 					"title": "Feature gates",
 					"type": "string"

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -1,9 +1,9 @@
 apiServer:
   enableAdmissionPlugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"
-  featureGates: "TTLAfterFinished=true"
+  featureGates: ""
   certSANs: []
 controllerManager:
-  featureGates: "ExpandPersistentVolumes=true,TTLAfterFinished=true"
+  featureGates: "ExpandPersistentVolumes=true"
 
 clusterDescription: ""  # Cluster description used in metadata.
 organization: ""  # The organization which owns this cluster.


### PR DESCRIPTION
This pr: ..

<details>
  <summary>How to run CI</summary>

Comment on this PR with:

```
/run cluster-test-suites
```
</details>