### PR TITLE
remove ExpandPersistentVolumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Remove `TTLAfterFinished` flag for Kubernetes 1.25 compatibility (enabled by default).
+- Remove `ExpandPersistentVolumes` flag for Kubernetes 1.27 compatibility (enabled by default).
 
 ## [0.9.2] - 2023-11-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.2] - 2023-11-15
 
+### Fixed
+
+- Minor fix and use of `--ignore-not-found` in IPAM.
+
 ## [0.9.1] - 2023-11-15
 
 ### Changed

--- a/helm/cluster-vsphere/files/kubelet-args
+++ b/helm/cluster-vsphere/files/kubelet-args
@@ -1,5 +1,5 @@
 cloud-provider: external
-feature-gates: "ExpandPersistentVolumes=true"
+feature-gates: ""
 eviction-hard : "memory.available<200Mi"
 eviction-max-pod-grace-period: "60"
 eviction-soft: "memory.available<500Mi"

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -3,7 +3,7 @@ apiServer:
   featureGates: ""
   certSANs: []
 controllerManager:
-  featureGates: "ExpandPersistentVolumes=true"
+  featureGates: ""
 
 clusterDescription: ""  # Cluster description used in metadata.
 organization: ""  # The organization which owns this cluster.


### PR DESCRIPTION
Enabled by default since 1.11 => https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/

<details>
  <summary>How to run CI</summary>

Comment on this PR with:

```
/run cluster-test-suites
```
</details>