### PR TITLE
Add KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.a…

### DIFF
--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -30,7 +30,9 @@ spec:
           {{- if $.Values.cluster.enableEncryptionProvider }}
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml
           {{- end }}
-          feature-gates: {{ .Values.apiServer.featureGates }}
+          {{- with .Values.apiServer.featureGates }}
+          feature-gates: {{ . }}
+          {{- end }}
           kubelet-preferred-address-types: "InternalIP"
           {{- if .Values.oidc.issuerUrl }}
           {{- with .Values.oidc }}


### PR DESCRIPTION
…piServer.extraArgs.feature-gates only if not empty

```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [unknown object type "nil" in KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.feature-gates, unknown object type "nil" in KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.controllerManager.extraArgs.feature-gates]
```

https://gigantic.slack.com/archives/C0561JVB0HY/p1702037593371539

/run cluster-test-suites