### PR TITLE
Fix templating issues for featureGates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix templating issues of feature-gates.
+
 ## [0.9.4] - 2023-12-11
 
 ## [0.9.3] - 2023-12-07

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -30,9 +30,7 @@ spec:
           {{- if $.Values.cluster.enableEncryptionProvider }}
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml
           {{- end }}
-          {{- with .Values.apiServer.featureGates }}
-          feature-gates: {{ . }}
-          {{- end }}
+          feature-gates: {{ .Values.apiServer.featureGates | quote }}
           kubelet-preferred-address-types: "InternalIP"
           {{- if .Values.oidc.issuerUrl }}
           {{- with .Values.oidc }}
@@ -75,7 +73,7 @@ spec:
           cloud-provider: external
           enable-hostpath-provisioner: "true"
           terminated-pod-gc-threshold: "125"
-          feature-gates: {{ .Values.controllerManager.featureGates }}
+          feature-gates: {{ .Values.controllerManager.featureGates | quote }}
           profiling: "false"
       dns:
         imageRepository: {{ .Values.controlPlane.dns.imageRepository }}

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -57,6 +57,21 @@
 			"title": "Kubernetes API server",
 			"type": "object"
 		},
+		"controllerManager": {
+			"properties": {
+				"featureGates": {
+					"default": "",
+					"description": "Enabled feature gates, as a comma-separated list.",
+					"title": "Feature gates",
+					"type": "string"
+				}
+			},
+			"required": [
+				"featureGates"
+			],
+			"title": "Kubernetes Controller Manager",
+			"type": "object"
+		},
 		"controlPlane": {
 			"properties": {
 				"etcd": {


### PR DESCRIPTION
We are receiving this error in the CI

```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [unknown object type "nil" in KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.feature-gates, unknown object type "nil" in KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.controllerManager.extraArgs.feature-gates]
```

This PR fixes the issue. 

<details>
  <summary>How to run CI</summary>

Comment on this PR with:

```
/run cluster-test-suites
```
</details>