### PR TITLE
Pull kube-vip image from Azure CR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Pull `kube-vip` image from Azure CR.
+
 ## [0.10.1] - 2024-03-07
 
 ### Changed

--- a/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
+++ b/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
@@ -36,7 +36,7 @@ stringData:
           value: "10"
         - name: vip_retryperiod
           value: "2"
-        image: docker.io/giantswarm/kube-vip:v0.7.2
+        image: gsoci.azurecr.io/giantswarm/kube-vip:v0.7.2
         imagePullPolicy: IfNotPresent
         name: kube-vip
         resources: {}


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/30271

This PR:

- Pull the `kube-vip` image from Azure CR.

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
