### PR TITLE
Move extra network policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Move extraPolicies from cilium-app to network-policies-app.
+
 ## [0.10.2] - 2024-04-02
 
 ### Changed

--- a/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
@@ -78,6 +78,7 @@ spec:
           operator: Exists
 {{- end }}
     extraPolicies:
+      remove: true
       allowEgressToCoreDNS:
-        enabled: true
+        enabled: false
 

--- a/helm/cluster-vsphere/templates/helmreleases/netpol-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/netpol-helmrelease.yaml
@@ -33,7 +33,9 @@ spec:
       retries: 30
   # Default values
   # https://github.com/giantswarm/network-policies-app/blob/main/helm/network-policies-app/values.yaml
-  # values:
+  values:
+    allowEgressToDNS:
+      enabled: true
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository


### PR DESCRIPTION


This PR disables the extra network policies on the cilium app and enable it on the network-policies-app

Towards https://github.com/giantswarm/roadmap/issues/3261

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites