### PR TITLE
Update teleport node labels cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Pull `kube-vip` image from Azure CR.
+- Update teleport node labels - add `ins=` label and remove `cluster=` label condition check, such that MC nodes have this label.
 
 ## [0.10.1] - 2024-03-07
 

--- a/helm/cluster-vsphere/files/etc/teleport.yaml
+++ b/helm/cluster-vsphere/files/etc/teleport.yaml
@@ -22,11 +22,9 @@ ssh_service:
     command: [/opt/teleport-node-role.sh]
     period: 1m0s
   labels:
+    ins: {{ .Values.managementCluster }}
     mc: {{ .Values.managementCluster }}
-    {{- $clusterName := include "resource.default.name" $ }}
-    {{- if ne .Values.managementCluster $clusterName }}
     cluster: {{ include "resource.default.name" $ }}
-    {{- end }}
     baseDomain: {{ .Values.baseDomain }}
 proxy_service:
   enabled: "no"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30398

### What does this PR do?
- Add new `ins=` label to all nodes, same value as mc= label
- Removes conditional check for `cluster=` label for MC nodes

### Any background context you can provide?

Currently, our labels doesn't support listing only MC nodes, because cluster= label is not present on MC nodes, only WC nodes and mc= label is common on all nodes.

In Web UI, we can filter by setting cluster="" but same doesn't work on Terminal tsh client.

```
$ tsh ssh root@mc=gazelle,cluster=
ERROR: invalid label spec: 'mc=gazelle,cluster=', should be 'key=value'

$ tsh ssh root@mc=gazelle,cluster=""
ERROR: invalid label spec: 'mc=gazelle,cluster=', should be 'key=value'
```

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites