### PR TITLE
Refactor helm values for compatibility with shared cluster chart

### DIFF
--- a/.github/workflows/zz_generated.check_values_schema.yaml
+++ b/.github/workflows/zz_generated.check_values_schema.yaml
@@ -1,6 +1,8 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.23.3
+#    devctl
+#
+#    https://github.com/giantswarm/devctl/blob/7a2bb1c2403407b720ec16e047f804471a57209e/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
 #
 name: 'Values and schema'
 on:
@@ -21,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/zz_generated.create_release.yaml
+++ b/.github/workflows/zz_generated.create_release.yaml
@@ -1,6 +1,8 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.23.3
+#    devctl
+#
+#    https://github.com/giantswarm/devctl/blob/7a2bb1c2403407b720ec16e047f804471a57209e/pkg/gen/input/workflows/internal/file/create_release.yaml.template
 #
 name: Create Release
 on:
@@ -52,7 +54,7 @@ jobs:
           echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Checkout code
         if: ${{ steps.get_version.outputs.version != '' }}
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       - name: Get project.go path
         id: get_project_go_path
         if: ${{ steps.get_version.outputs.version != '' }}
@@ -101,7 +103,7 @@ jobs:
           tarball_binary_path: "*/src/${binary}"
           smoke_test: "${binary} --version"
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       - name: Update project.go
         id: update_project_go
         env:
@@ -161,7 +163,7 @@ jobs:
       upload_url: ${{ steps.create_gh_release.outputs.upload_url }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
         with:
           ref: ${{ github.sha }}
       - name: Ensure correct version in project.go
@@ -214,7 +216,7 @@ jobs:
           tarball_binary_path: "*/src/${binary}"
           smoke_test: "${binary} --version"
       - name: Check out the repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
         with:
           fetch-depth: 0  # Clone the whole history, not just the most recent commit.
       - name: Fetch all tags and branches

--- a/.github/workflows/zz_generated.create_release_pr.yaml
+++ b/.github/workflows/zz_generated.create_release_pr.yaml
@@ -1,6 +1,8 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.23.3
+#    devctl
+#
+#    https://github.com/giantswarm/devctl/blob/7a2bb1c2403407b720ec16e047f804471a57209e/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
 #
 name: Create Release PR
 on:
@@ -152,7 +154,7 @@ jobs:
           binary: "architect"
           version: "6.11.0"
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
         with:
           ref: ${{ needs.gather_facts.outputs.branch }}
       - name: Prepare release changes

--- a/.github/workflows/zz_generated.gitleaks.yaml
+++ b/.github/workflows/zz_generated.gitleaks.yaml
@@ -1,6 +1,8 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.23.3
+#    devctl
+#
+#    https://github.com/giantswarm/devctl/blob/7a2bb1c2403407b720ec16e047f804471a57209e/pkg/gen/input/workflows/internal/file/gitleaks.yaml.template
 #
 name: gitleaks
 
@@ -10,7 +12,7 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       with:
         fetch-depth: '0'
     - name: gitleaks-action

--- a/.github/workflows/zz_generated.run_ossf_scorecard.yaml
+++ b/.github/workflows/zz_generated.run_ossf_scorecard.yaml
@@ -1,6 +1,8 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.23.3
+#    devctl
+#
+#    https://github.com/giantswarm/devctl/blob/7a2bb1c2403407b720ec16e047f804471a57209e/pkg/gen/input/workflows/internal/file/run_ossf_scorecard.yaml.template
 #
 
 # This workflow uses actions that are not certified by GitHub. They are provided
@@ -38,7 +40,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
         with:
           persist-credentials: false
 
@@ -65,7 +67,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: SARIF file
           path: results.sarif
@@ -73,6 +75,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@1b1aada464948af03b950897e5eb522f92603cc2 # v3.24.9
+        uses: github/codeql-action/upload-sarif@8f596b4ae3cb3c588a5c46780b86dd53fef16c52 # v3.25.2
         with:
           sarif_file: results.sarif

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.23.3
+#    devctl
+#
+#    https://github.com/giantswarm/devctl/blob/7a2bb1c2403407b720ec16e047f804471a57209e/pkg/gen/input/makefile/internal/file/Makefile.template
 #
 
 include Makefile.*.mk

--- a/Makefile.gen.app.mk
+++ b/Makefile.gen.app.mk
@@ -1,6 +1,8 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.23.3
+#    devctl
+#
+#    https://github.com/giantswarm/devctl/blob/7a2bb1c2403407b720ec16e047f804471a57209e/pkg/gen/input/makefile/internal/file/Makefile.gen.app.mk.template
 #
 
 ##@ App

--- a/helm/cluster-vsphere/files/etc/containerd/config.toml
+++ b/helm/cluster-vsphere/files/etc/containerd/config.toml
@@ -25,7 +25,7 @@ sandbox_image = "{{ .Values.internal.sandboxContainerImage.registry }}/{{ .Value
 
 [plugins."io.containerd.grpc.v1.cri".registry]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-  {{- range $host, $config := .Values.connectivity.containerRegistries }}
+  {{- range $host, $config := .Values.global.connectivity.containerRegistries }}
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{$host}}"]
       endpoint = [
         {{- range $value := $config -}}
@@ -34,7 +34,7 @@ sandbox_image = "{{ .Values.internal.sandboxContainerImage.registry }}/{{ .Value
     ]
   {{- end }}
 [plugins."io.containerd.grpc.v1.cri".registry.configs]
-  {{ range $host, $config := .Values.connectivity.containerRegistries -}}
+  {{ range $host, $config := .Values.global.connectivity.containerRegistries -}}
     {{ range $value := $config -}}
       {{ with $value.credentials -}}
       [plugins."io.containerd.grpc.v1.cri".registry.configs."{{$value.endpoint}}".auth]

--- a/helm/cluster-vsphere/files/etc/teleport.yaml
+++ b/helm/cluster-vsphere/files/etc/teleport.yaml
@@ -25,6 +25,6 @@ ssh_service:
     ins: {{ .Values.managementCluster }}
     mc: {{ .Values.managementCluster }}
     cluster: {{ include "resource.default.name" $ }}
-    baseDomain: {{ .Values.baseDomain }}
+    baseDomain: {{ .Values.global.connectivity.baseDomain }}
 proxy_service:
   enabled: "no"

--- a/helm/cluster-vsphere/templates/_cluster_dns.tpl
+++ b/helm/cluster-vsphere/templates/_cluster_dns.tpl
@@ -8,10 +8,10 @@
     replaced with .10.
 */}}
 {{- define "clusterDNS" -}}
-    {{- $serviceCidrBlock := index .Values.connectivity.network.services.cidrBlocks 0 -}}
+    {{- $serviceCidrBlock := index .Values.global.connectivity.network.services.cidrBlocks 0 -}}
     {{- $mask := int (mustRegexReplaceAll `^.*/(\d+)$` $serviceCidrBlock "${1}") -}}
     {{- if gt $mask 24 -}}
-        {{- fail (printf ".Values.connectivity.network.services.cidrBlocks[0]=%q mask must be <= 24" $serviceCidrBlock) -}}
+        {{- fail (printf ".Values.global.connectivity.network.services.cidrBlocks[0]=%q mask must be <= 24" $serviceCidrBlock) -}}
     {{- end -}}
     {{- mustRegexReplaceAll `^(\d+\.\d+\.\d+).*$` $serviceCidrBlock "${1}.10" -}}
 {{- end -}}

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -163,7 +163,7 @@ postKubeadmCommands:
 
 {{- define "mtRevisionByControlPlane" -}}
 {{- $outerScope := . }}
-{{- include "mtRevision" (merge (dict "currentClass" .Values.controlPlane.machineTemplate) $outerScope.Values) }}
+{{- include "mtRevision" (merge (dict "currentClass" .Values.global.controlPlane.machineTemplate) $outerScope.Values) }}
 {{- end -}}
 
 {{/*

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -24,10 +24,10 @@ Here we are generating a hash suffix to trigger upgrade when only it is necessar
 using only the parameters used in vspheredmachinetemplate.yaml.
 */}}
 {{- define "mtSpec" -}}
-datacenter: {{ $.vcenter.datacenter }}
-datastore: {{ $.vcenter.datastore }}
-server: {{ $.vcenter.server }}
-thumbprint: {{ $.vcenter.thumbprint }}
+datacenter: {{ $.global.providerSpecific.vcenter.datacenter }}
+datastore: {{ $.global.providerSpecific.vcenter.datastore }}
+server: {{ $.global.providerSpecific.vcenter.server }}
+thumbprint: {{ $.global.providerSpecific.vcenter.thumbprint }}
 {{ toYaml .currentClass }}
 {{- end -}}
 

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -127,14 +127,14 @@ files:
   {{- include "sshFiles" . | nindent 2}}
   {{- include "teleportFiles" . | nindent 2 }}
   {{- include "containerdConfig" . | nindent 2 }}
-  {{- if $.Values.proxy.enabled }}
+  {{- if $.Values.global.connectivity.proxy.enabled }}
     {{- include "containerdProxyConfig" . | nindent 2}}
     {{- include "teleportProxyConfig" . | nindent 2 }}
   {{- end }}
 preKubeadmCommands:
 {{ include "sshPreKubeadmCommands" . }}
 - /bin/test ! -d /var/lib/kubelet && (/bin/mkdir -p /var/lib/kubelet && /bin/chmod 0750 /var/lib/kubelet)
-  {{- if $.Values.proxy.enabled }}
+  {{- if $.Values.global.connectivity.proxy.enabled }}
 - systemctl daemon-reload
 - systemctl restart containerd
   {{- if $.Values.internal.teleport.enabled }}

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -65,7 +65,7 @@ helm.sh/chart: {{ include "chart" . | quote }}
 Create label to prevent accidental cluster deletion
 */}}
 {{- define "preventDeletionLabel" -}}
-{{- if $.Values.metadata.preventDeletion -}}
+{{- if $.Values.global.metadata.preventDeletion -}}
 giantswarm.io/prevent-deletion: "true"
 {{ end -}}
 {{- end -}}

--- a/helm/cluster-vsphere/templates/_ssh.tpl
+++ b/helm/cluster-vsphere/templates/_ssh.tpl
@@ -3,11 +3,11 @@
 
 
 {{- define "sshFiles" -}}
-{{- if $.Values.sshTrustedUserCAKeys -}}
+{{- if $.Values.global.connectivity.shell.sshTrustedUserCAKeys -}}
 - path: /etc/ssh/trusted-user-ca-keys.pem
   permissions: "0600"
   content: |
-    {{- range $.Values.sshTrustedUserCAKeys}}
+    {{- range $.Values.global.connectivity.shell.sshTrustedUserCAKeys}}
     {{.}}
     {{- end }}
 - path: /etc/ssh/sshd_config
@@ -22,8 +22,8 @@
 {{- end -}}
 
 {{- define "sshUsers" -}}
-{{- if $.Values.osUsers -}}
+{{- if $.Values.global.connectivity.shell.osUsers -}}
 users:
-  {{- $.Values.osUsers | toYaml | nindent 2}}
+  {{- $.Values.global.connectivity.shell.osUsers | toYaml | nindent 2}}
 {{- end }}
 {{- end -}}

--- a/helm/cluster-vsphere/templates/cluster.yaml
+++ b/helm/cluster-vsphere/templates/cluster.yaml
@@ -20,12 +20,12 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        {{- range .Values.connectivity.network.pods.cidrBlocks }}
+        {{- range .Values.global.connectivity.network.pods.cidrBlocks }}
         - {{ . }}
         {{- end }}
     services:
       cidrBlocks:
-        {{- range .Values.connectivity.network.services.cidrBlocks }}
+        {{- range .Values.global.connectivity.network.services.cidrBlocks }}
         - {{ . }}
         {{- end }}
   controlPlaneRef:

--- a/helm/cluster-vsphere/templates/cluster.yaml
+++ b/helm/cluster-vsphere/templates/cluster.yaml
@@ -4,12 +4,12 @@ metadata:
   name: {{ include "resource.default.name" $ }}
   namespace: {{ .Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
   labels:
     cluster-apps-operator.giantswarm.io/watching: ""
-    giantswarm.io/service-priority: "{{ .Values.servicePriority }}"
+    giantswarm.io/service-priority: "{{ .Values.global.metadata.servicePriority }}"
     {{- include "labels.common" . | nindent 4 }}
-    {{- range $key, $val := .Values.clusterLabels }}
+    {{- range $key, $val := .Values.global.metadata.labels }}
     {{ $key }}: {{ $val | quote }}
     {{- end}}
     {{- if .Values.global.podSecurityStandards.enforced }}

--- a/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
       chart: cilium
       # used by renovate
       # repo: giantswarm/cilium-app
-      version: 0.22.0
+      version: 0.23.0
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default

--- a/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
@@ -4,10 +4,10 @@ metadata:
   name: {{ include "resource.default.name" $ }}-cilium
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
   labels:
     cluster-apps-operator.giantswarm.io/watching: ""
-    giantswarm.io/service-priority: "{{ .Values.servicePriority }}"
+    giantswarm.io/service-priority: "{{ .Values.global.metadata.servicePriority }}"
     {{- include "labels.common" . | nindent 4 }}
 spec:
   releaseName: cilium

--- a/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
       chart: cilium
       # used by renovate
       # repo: giantswarm/cilium-app
-      version: 0.23.0
+      version: 0.24.0
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default

--- a/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
   values:
     ipam:
       mode: kubernetes
-    k8sServiceHost: api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}
+    k8sServiceHost: api.{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}
     k8sServicePort: "6443"
     kubeProxyReplacement: strict
     global:

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -55,7 +55,7 @@ spec:
       podSecurityStandards:
         enforced: {{ .Values.global.podSecurityStandards.enforced }}
     kube-vip-cloud-provider:
-      cidrGlobal: '{{ join "," .Values.connectivity.network.loadBalancers.cidrBlocks }}'
+      cidrGlobal: '{{ join "," .Values.global.connectivity.network.loadBalancers.cidrBlocks }}'
       image:
         repository: docker.io/giantswarm/kube-vip-cloud-provider
         tag: v0.0.4

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -47,11 +47,11 @@ spec:
       config:
         enabled: true
         clusterId: {{ include "resource.default.name" $ }}
-        vcenter: "{{ .Values.vcenter.server }}"
-        datacenter: "{{ .Values.vcenter.datacenter }}"
-        region: "{{ .Values.vcenter.region }}"
-        zone: "{{ .Values.vcenter.zone }}"
-        thumbprint: "{{ .Values.vcenter.thumbprint }}"
+        vcenter: "{{ .Values.global.providerSpecific.vcenter.server }}"
+        datacenter: "{{ .Values.global.providerSpecific.vcenter.datacenter }}"
+        region: "{{ .Values.global.providerSpecific.vcenter.region }}"
+        zone: "{{ .Values.global.providerSpecific.vcenter.zone }}"
+        thumbprint: "{{ .Values.global.providerSpecific.vcenter.thumbprint }}"
       podSecurityStandards:
         enforced: {{ .Values.global.podSecurityStandards.enforced }}
     kube-vip-cloud-provider:

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -4,10 +4,10 @@ metadata:
   name: {{ include "resource.default.name" $ }}-cloud-provider-vsphere
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
   labels:
     cluster-apps-operator.giantswarm.io/watching: ""
-    giantswarm.io/service-priority: "{{ .Values.servicePriority }}"
+    giantswarm.io/service-priority: "{{ .Values.global.metadata.servicePriority }}"
     {{- include "labels.common" . | nindent 4 }}
 spec:
   suspend: {{ include "isIpamSvcLoadBalancerEnabled" $ }} # It is unsuspended by the post-install/post-upgrade hook.

--- a/helm/cluster-vsphere/templates/helmreleases/coredns-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/coredns-helmrelease.yaml
@@ -35,10 +35,10 @@ spec:
   values:
     cluster:
       calico:
-        CIDR: {{ index .Values.connectivity.network.pods.cidrBlocks 0 | quote }}
+        CIDR: {{ index .Values.global.connectivity.network.pods.cidrBlocks 0 | quote }}
       kubernetes:
         API:
-          clusterIPRange: {{ index .Values.connectivity.network.services.cidrBlocks 0 | quote }}
+          clusterIPRange: {{ index .Values.global.connectivity.network.services.cidrBlocks 0 | quote }}
         DNS:
           IP: {{ include "clusterDNS" $ | quote }}
     global:

--- a/helm/cluster-vsphere/templates/helmreleases/coredns-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/coredns-helmrelease.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-coredns
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/cluster-vsphere/templates/helmreleases/default-helmrepository.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/default-helmrepository.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-default
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
@@ -17,7 +17,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-default-test
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/cluster-vsphere/templates/helmreleases/netpol-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/netpol-helmrelease.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-network-policies
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
@@ -43,7 +43,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-cluster
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/cluster-vsphere/templates/ipam/_ipam.tpl
+++ b/helm/cluster-vsphere/templates/ipam/_ipam.tpl
@@ -1,13 +1,13 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{- define "isIpamControlPlaneIPEnabled" -}}
-    {{- if and (and (not .Values.connectivity.network.controlPlaneEndpoint.host) (.Values.connectivity.network.controlPlaneEndpoint.ipPoolName)) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1alpha1/IPAddressClaim") }}
+    {{- if and (and (not .Values.global.connectivity.network.controlPlaneEndpoint.host) (.Values.global.connectivity.network.controlPlaneEndpoint.ipPoolName)) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1alpha1/IPAddressClaim") }}
         {{- printf "true" -}}
     {{- end }}
 {{- end }}
 
 {{- define "isIpamSvcLoadBalancerEnabled" -}}
-    {{- if and (.Values.connectivity.network.loadBalancers.ipPoolName) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1alpha1/IPAddressClaim") }}
+    {{- if and (.Values.global.connectivity.network.loadBalancers.ipPoolName) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1alpha1/IPAddressClaim") }}
         {{- printf "true" -}}
     {{- end }}
 {{- end }}

--- a/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
+++ b/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
@@ -129,8 +129,8 @@ spec:
               echo "Got the IP: ${new_ip}"
               new_ip="${new_ip}/32"
               # patch the cloud-provider-vsphere-helmrelease
-              {{- if .Values.connectivity.network.loadBalancers.cidrBlocks }}
-              new_ip="${new_ip},{{ join "," .Values.connectivity.network.loadBalancers.cidrBlocks }}"
+              {{- if .Values.global.connectivity.network.loadBalancers.cidrBlocks }}
+              new_ip="${new_ip},{{ join "," .Values.global.connectivity.network.loadBalancers.cidrBlocks }}"
               {{- end }}
               kubectl patch helmrelease -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }}-cloud-provider-vsphere --type=merge -p '{"spec":{"suspend":false,"values":{"kube-vip-cloud-provider": {"cidrGlobal": "'${new_ip}'"}}}}'
 {{- end }}

--- a/helm/cluster-vsphere/templates/ipam/ipAddressClaim.yaml
+++ b/helm/cluster-vsphere/templates/ipam/ipAddressClaim.yaml
@@ -9,5 +9,5 @@ spec:
   poolRef:
     apiGroup: ipam.cluster.x-k8s.io
     kind: GlobalInClusterIPPool
-    name: {{ .Values.connectivity.network.controlPlaneEndpoint.ipPoolName }}
+    name: {{ .Values.global.connectivity.network.controlPlaneEndpoint.ipPoolName }}
 {{- end }}

--- a/helm/cluster-vsphere/templates/ipam/ipAddressClaimLB.yaml
+++ b/helm/cluster-vsphere/templates/ipam/ipAddressClaimLB.yaml
@@ -9,5 +9,5 @@ spec:
   poolRef:
     apiGroup: ipam.cluster.x-k8s.io
     kind: GlobalInClusterIPPool
-    name: {{ .Values.connectivity.network.loadBalancers.ipPoolName }}
+    name: {{ .Values.global.connectivity.network.loadBalancers.ipPoolName }}
 {{- end }}

--- a/helm/cluster-vsphere/templates/kubeadmconfigtemplate.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmconfigtemplate.yaml
@@ -1,4 +1,4 @@
-{{- range $name, $value := .Values.nodePools }}
+{{- range $name, $value := .Values.global.nodePools }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -82,7 +82,9 @@ spec:
           cloud-provider: external
           enable-hostpath-provisioner: "true"
           terminated-pod-gc-threshold: "125"
-          feature-gates: {{ .Values.controllerManager.featureGates | quote }}
+          feature-gates: {{ range $index, $element := .Values.internal.controllerManager.featureGates -}}
+            {{ if $index }},{{ end }}{{ $element.name }}={{ $element.enabled }}
+          {{- end }}
           profiling: "false"
       dns:
         imageRepository: {{ .Values.global.controlPlane.dns.imageRepository }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -33,7 +33,10 @@ spec:
           {{- if $.Values.cluster.enableEncryptionProvider }}
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml
           {{- end }}
-          feature-gates: {{ .Values.apiServer.featureGates | quote }}
+          {{- if .Values.internal.apiServer.featureGates }}
+          feature-gates: {{ range $index, $element := .Values.internal.apiServer.featureGates -}}
+            {{ if $index }},{{ end }}{{ $element.name }}={{ $element.enabled }}
+          {{- end }}
           kubelet-preferred-address-types: "InternalIP"
           {{- if .Values.global.controlPlane.oidc.issuerUrl }}
           {{- with .Values.global.controlPlane.oidc }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -170,4 +170,4 @@ spec:
       name: {{ include "resource.default.name" . }}-control-plane-{{ include "mtRevisionByControlPlane" $ }}
       namespace: {{ .Release.Namespace }}
   replicas: {{ .Values.global.controlPlane.replicas }}
-  version: {{ .Values.cluster.kubernetesVersion }}
+  version: {{ .Values.internal.kubernetesVersion }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -30,7 +30,7 @@ spec:
           {{- if .Values.internal.apiServer.enableAdmissionPlugins }}
           enable-admission-plugins: {{ .Values.internal.apiServer.enableAdmissionPlugins | join "," | quote }}
           {{- end }}
-          {{- if $.Values.cluster.enableEncryptionProvider }}
+          {{- if $.Values.internal.enableEncryptionProvider }}
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml
           {{- end }}
           {{- if .Values.internal.apiServer.featureGates }}
@@ -69,7 +69,7 @@ spec:
             hostPath: /etc/kubernetes/policies
             mountPath: /etc/kubernetes/policies
             pathType: DirectoryOrCreate
-          {{- if $.Values.cluster.enableEncryptionProvider }}
+          {{- if $.Values.internal.enableEncryptionProvider }}
           - name: encryption
             hostPath: /etc/kubernetes/encryption
             mountPath: /etc/kubernetes/encryption
@@ -144,7 +144,7 @@ spec:
         content: |-
           {{- $.Files.Get $kubeadmPatch | nindent 10 }}
       {{- end }}
-      {{- if $.Values.cluster.enableEncryptionProvider }}
+      {{- if $.Values.internal.enableEncryptionProvider }}
       - path: /etc/kubernetes/encryption/config.yaml
         permissions: "0600"
         contentFrom:

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -27,7 +27,9 @@ spec:
           audit-log-path: /var/log/apiserver/audit.log
           audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
           cloud-provider: external
-          enable-admission-plugins: {{ .Values.apiServer.enableAdmissionPlugins }}
+          {{- if .Values.internal.apiServer.enableAdmissionPlugins }}
+          enable-admission-plugins: {{ .Values.internal.apiServer.enableAdmissionPlugins | join "," | quote }}
+          {{- end }}
           {{- if $.Values.cluster.enableEncryptionProvider }}
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml
           {{- end }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -15,7 +15,7 @@ spec:
         - localhost
         - 127.0.0.1
         - "api.{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}"
-        {{- with .Values.apiServer.certSANs }}
+        {{- with .Values.internal.apiServer.certSANs }}
         {{- range . }}
         - {{ . }}
         {{- end }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -33,14 +33,17 @@ spec:
           {{- end }}
           feature-gates: {{ .Values.apiServer.featureGates | quote }}
           kubelet-preferred-address-types: "InternalIP"
-          {{- if .Values.oidc.issuerUrl }}
-          {{- with .Values.oidc }}
+          {{- if .Values.global.controlPlane.oidc.issuerUrl }}
+          {{- with .Values.global.controlPlane.oidc }}
           oidc-issuer-url: {{ .issuerUrl }}
           oidc-client-id: {{ .clientId }}
           oidc-username-claim: {{ .usernameClaim }}
           oidc-groups-claim: {{ .groupsClaim }}
           {{- if .usernamePrefix }}
           oidc-username-prefix: {{ .usernamePrefix | quote }}
+          {{- end }}
+          {{- if .groupsPrefix }}
+          oidc-groups-prefix: {{ .groupsPrefix | quote }}
           {{- end }}
           {{- if .caFile }}
           oidc-ca-file: {{ .caFile }}
@@ -77,15 +80,15 @@ spec:
           feature-gates: {{ .Values.controllerManager.featureGates | quote }}
           profiling: "false"
       dns:
-        imageRepository: {{ .Values.controlPlane.dns.imageRepository }}
-        imageTag: {{ .Values.controlPlane.dns.imageTag }}
+        imageRepository: {{ .Values.global.controlPlane.dns.imageRepository }}
+        imageTag: {{ .Values.global.controlPlane.dns.imageTag }}
       etcd:
         local:
           extraArgs:
             listen-metrics-urls: "http://0.0.0.0:2381"
-          imageRepository: {{ .Values.controlPlane.etcd.imageRepository }}
-          imageTag: {{ .Values.controlPlane.etcd.imageTag }}
-      imageRepository: {{ .Values.controlPlane.image.repository }}
+          imageRepository: {{ .Values.global.controlPlane.etcd.imageRepository }}
+          imageTag: {{ .Values.global.controlPlane.etcd.imageTag }}
+      imageRepository: {{ .Values.global.controlPlane.image.repository }}
       scheduler:
         extraArgs:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
@@ -143,7 +146,7 @@ spec:
       {{- end }}
     preKubeadmCommands:
       {{- include "sshPreKubeadmCommands" . | nindent 6 }}
-      - bash /etc/kubernetes/patches/kube-apiserver-patch.sh {{ .Values.controlPlane.resourceRatio }}
+      - bash /etc/kubernetes/patches/kube-apiserver-patch.sh {{ .Values.global.controlPlane.resourceRatio }}
       - /bin/test ! -d /var/lib/kubelet && (/bin/mkdir -p /var/lib/kubelet && /bin/chmod 0750 /var/lib/kubelet)
       {{- if $.Values.proxy.enabled }}
       - systemctl daemon-reload
@@ -158,5 +161,5 @@ spec:
       kind: VSphereMachineTemplate
       name: {{ include "resource.default.name" . }}-control-plane-{{ include "mtRevisionByControlPlane" $ }}
       namespace: {{ .Release.Namespace }}
-  replicas: {{ .Values.controlPlane.replicas }}
+  replicas: {{ .Values.global.controlPlane.replicas }}
   version: {{ .Values.cluster.kubernetesVersion }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -14,7 +14,7 @@ spec:
         - {{ .Values.global.connectivity.network.controlPlaneEndpoint.host }}
         - localhost
         - 127.0.0.1
-        - "api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
+        - "api.{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}"
         {{- with .Values.apiServer.certSANs }}
         {{- range . }}
         - {{ . }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -37,6 +37,7 @@ spec:
           feature-gates: {{ range $index, $element := .Values.internal.apiServer.featureGates -}}
             {{ if $index }},{{ end }}{{ $element.name }}={{ $element.enabled }}
           {{- end }}
+          {{- end }}
           kubelet-preferred-address-types: "InternalIP"
           {{- if .Values.global.controlPlane.oidc.issuerUrl }}
           {{- with .Values.global.controlPlane.oidc }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -11,7 +11,7 @@ spec:
     clusterConfiguration:
       apiServer:
         certSANs:
-        - {{ .Values.connectivity.network.controlPlaneEndpoint.host }}
+        - {{ .Values.global.connectivity.network.controlPlaneEndpoint.host }}
         - localhost
         - 127.0.0.1
         - "api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
@@ -91,7 +91,7 @@ spec:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
           bind-address: "0.0.0.0"
       networking:
-        serviceSubnet: {{ join "," .Values.connectivity.network.services.cidrBlocks }}
+        serviceSubnet: {{ join "," .Values.global.connectivity.network.services.cidrBlocks }}
     {{- include "sshUsers" . | nindent 4 }}
     {{- include "ignitionSpec" . | nindent 4 }}
     initConfiguration:

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -133,7 +133,7 @@ spec:
       {{- include "sshFiles" . | nindent 6}}
       {{- include "teleportFiles" . | nindent 6 }}
       {{- include "auditLogFiles" . | nindent 6 }}
-      {{- if $.Values.proxy.enabled }}
+      {{- if $.Values.global.connectivity.proxy.enabled }}
       {{- include "containerdProxyConfig" . | nindent 6}}
       {{- include "teleportProxyConfig" . | nindent 6 }}
       {{- end }}
@@ -156,7 +156,7 @@ spec:
       {{- include "sshPreKubeadmCommands" . | nindent 6 }}
       - bash /etc/kubernetes/patches/kube-apiserver-patch.sh {{ .Values.global.controlPlane.resourceRatio }}
       - /bin/test ! -d /var/lib/kubelet && (/bin/mkdir -p /var/lib/kubelet && /bin/chmod 0750 /var/lib/kubelet)
-      {{- if $.Values.proxy.enabled }}
+      {{- if $.Values.global.connectivity.proxy.enabled }}
       - systemctl daemon-reload
       - systemctl restart containerd
       {{- if $.Values.internal.teleport.enabled }}

--- a/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
+++ b/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
@@ -27,7 +27,7 @@ stringData:
         - name: vip_leaderelection
           value: "true"
         - name: vip_address
-          value: {{ .Values.connectivity.network.controlPlaneEndpoint.host }}
+          value: {{ .Values.global.connectivity.network.controlPlaneEndpoint.host }}
         - name: vip_interface
           value: ens192
         - name: vip_leaseduration

--- a/helm/cluster-vsphere/templates/machinedeployment.yaml
+++ b/helm/cluster-vsphere/templates/machinedeployment.yaml
@@ -1,4 +1,4 @@
-{{- range $name, $value := .Values.nodePools }}
+{{- range $name, $value := .Values.global.nodePools }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/helm/cluster-vsphere/templates/machinedeployment.yaml
+++ b/helm/cluster-vsphere/templates/machinedeployment.yaml
@@ -31,5 +31,5 @@ spec:
         kind: VSphereMachineTemplate
         name: {{ include "resource.default.name" $ }}-{{ $value.class }}-{{ include "mtRevisionByClass" (merge (dict "currentValues" $.Values) $value) }}
         namespace: {{ $.Release.Namespace }}
-      version: {{ $.Values.cluster.kubernetesVersion }}
+      version: {{ $.Values.internal.kubernetesVersion }}
 {{- end }}

--- a/helm/cluster-vsphere/templates/provider-secret.yaml
+++ b/helm/cluster-vsphere/templates/provider-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
 data:
-  username: {{ .Values.vcenter.username | b64enc | quote }}
-  password: {{ .Values.vcenter.password | b64enc | quote }}
+  username: {{ .Values.global.providerSpecific.vcenter.username | b64enc | quote }}
+  password: {{ .Values.global.providerSpecific.vcenter.password | b64enc | quote }}
   # https://github.com/fluxcd/flux2/issues/2625
-  escapedPassword: {{ .Values.vcenter.password | replace "." "\\." | replace "," "\\," | b64enc | quote }}
+  escapedPassword: {{ .Values.global.providerSpecific.vcenter.password | replace "." "\\." | replace "," "\\," | b64enc | quote }}

--- a/helm/cluster-vsphere/templates/vspherecluster.yaml
+++ b/helm/cluster-vsphere/templates/vspherecluster.yaml
@@ -8,8 +8,8 @@ metadata:
     {{- include "preventDeletionLabel" $ | nindent 4 }}
 spec:
   controlPlaneEndpoint:
-    host: '{{ ((.Values.connectivity.network).controlPlaneEndpoint).host }}'
-    port: {{ ((.Values.connectivity.network).controlPlaneEndpoint).port | default 6443 }}
+    host: '{{ ((.Values.global.connectivity.network).controlPlaneEndpoint).host }}'
+    port: {{ ((.Values.global.connectivity.network).controlPlaneEndpoint).port | default 6443 }}
 
   identityRef:
     kind: Secret

--- a/helm/cluster-vsphere/templates/vspherecluster.yaml
+++ b/helm/cluster-vsphere/templates/vspherecluster.yaml
@@ -14,5 +14,5 @@ spec:
   identityRef:
     kind: Secret
     name: {{ include "credentialSecretName" $ }}
-  server: {{ .Values.vcenter.server }}
-  thumbprint: {{ .Values.vcenter.thumbprint }}
+  server: {{ .Values.global.providerSpecific.vcenter.server }}
+  thumbprint: {{ .Values.global.providerSpecific.vcenter.thumbprint }}

--- a/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
+++ b/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
@@ -1,4 +1,4 @@
-{{- range $name, $value := (merge .Values.nodeClasses (dict "control-plane" .Values.controlPlane.machineTemplate)) }}
+{{- range $name, $value := (merge .Values.nodeClasses (dict "control-plane" .Values.global.controlPlane.machineTemplate)) }}
 {{- $c := (merge (dict "currentClass"  $value) $.Values) }}
 ---
 apiVersion: {{ include "infrastructureApiVersion" . }}

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -245,6 +245,24 @@
 							"title": "Network",
 							"type": "object"
 						},
+						"proxy": {
+							"type": "object",
+							"title": "Proxy",
+							"description": "Whether/how outgoing traffic is routed through proxy servers.",
+							"additionalProperties": false,
+							"properties": {
+								"enabled": {
+									"type": "boolean",
+									"title": "Enable"
+								},
+								"secretName": {
+									"type": "string",
+									"title": "Secret name",
+									"description": "Name of a secret resource used by containerd to obtain the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables. If empty the value will be defaulted to <clusterName>-cluster-values.",
+									"pattern": "^[a-z0-9-]{0,63}$"
+								}
+							}
+						},
 						"shell": {
 							"type": "object",
 							"properties": {

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -78,68 +78,6 @@
 			"title": "Kubernetes Controller Manager",
 			"type": "object"
 		},
-		"controlPlane": {
-			"properties": {
-				"dns": {
-                    "type": "object",
-                    "title": "DNS container image",
-                    "additionalProperties": false,
-                    "properties": {
-                        "imageRepository": {
-                            "type": "string",
-                            "title": "Repository",
-                            "default": "gsoci.azurecr.io/giantswarm"
-                        },
-                        "imageTag": {
-                            "type": "string",
-                            "title": "Tag",
-                            "default": "1.9.4-giantswarm"
-                        }
-                    }
-                },
-                "etcd": {
-                    "type": "object",
-                    "title": "Etcd container image",
-                    "additionalProperties": false,
-                    "properties": {
-                        "imageRepository": {
-                            "type": "string",
-                            "title": "Repository",
-                            "default": "gsoci.azurecr.io/giantswarm"
-                        },
-                        "imageTag": {
-                            "type": "string",
-                            "title": "Tag",
-                            "default": "3.5.4-0-k8s"
-                        }
-                    }
-                },
-                "image": {
-                    "type": "object",
-                    "title": "Node container image",
-                    "additionalProperties": false,
-                    "properties": {
-                        "repository": {
-                            "type": "string",
-                            "title": "Repository",
-                            "default": "gsoci.azurecr.io/giantswarm"
-                        }
-                    }
-                },
-				"replicas": {
-					"title": "Number of nodes",
-					"type": "integer"
-				},
-				"resourceRatio": {
-					"title": "Resource ratio",
-					"description": "Ratio between node resources and apiserver resource requests.",
-					"default": 8,
-					"type": "integer"
-				}
-			},
-			"title": "Control plane",
-			"type": "object"
-		},
         "global": {
             "type": "object",
             "title": "Global parameters",
@@ -340,6 +278,116 @@
 						"network"
 					],
 					"title": "Connectivity",
+					"type": "object"
+				},
+				"controlPlane": {
+					"properties": {
+						"dns": {
+							"type": "object",
+							"title": "DNS container image",
+							"additionalProperties": false,
+							"properties": {
+								"imageRepository": {
+									"type": "string",
+									"title": "Repository",
+									"default": "gsoci.azurecr.io/giantswarm"
+								},
+								"imageTag": {
+									"type": "string",
+									"title": "Tag",
+									"default": "1.9.4-giantswarm"
+								}
+							}
+						},
+						"etcd": {
+							"type": "object",
+							"title": "Etcd container image",
+							"additionalProperties": false,
+							"properties": {
+								"imageRepository": {
+									"type": "string",
+									"title": "Repository",
+									"default": "gsoci.azurecr.io/giantswarm"
+								},
+								"imageTag": {
+									"type": "string",
+									"title": "Tag",
+									"default": "3.5.4-0-k8s"
+								}
+							}
+						},
+						"image": {
+							"type": "object",
+							"title": "Node container image",
+							"additionalProperties": false,
+							"properties": {
+								"repository": {
+									"type": "string",
+									"title": "Repository",
+									"default": "gsoci.azurecr.io/giantswarm"
+								}
+							}
+						},
+						"replicas": {
+							"title": "Number of nodes",
+							"type": "integer"
+						},
+						"resourceRatio": {
+							"title": "Resource ratio",
+							"description": "Ratio between node resources and apiserver resource requests.",
+							"default": 8,
+							"type": "integer"
+						},
+						"oidc": {
+							"type": "object",
+							"title": "OIDC authentication",
+							"required": [
+								"clientId",
+								"groupsClaim",
+								"issuerUrl",
+								"usernameClaim"
+							],
+							"additionalProperties": false,
+							"properties": {
+								"caFile": {
+									"type": "string",
+									"title": "Certificate authority file",
+									"description": "Path to identity provider's CA certificate in PEM format."
+								},
+								"clientId": {
+									"type": "string",
+									"title": "Client ID",
+									"description": "OIDC client identifier to identify with."
+								},
+								"groupsClaim": {
+									"type": "string",
+									"title": "Groups claim",
+									"description": "Name of the identity token claim bearing the user's group memberships."
+								},
+								"groupsPrefix": {
+									"type": "string",
+									"title": "Groups prefix",
+									"description": "Prefix prepended to groups values to prevent clashes with existing names."
+								},
+								"issuerUrl": {
+									"type": "string",
+									"title": "Issuer URL",
+									"description": "URL of the provider which allows the API server to discover public signing keys, not including any path. Discovery URL without the '/.well-known/openid-configuration' part."
+								},
+								"usernameClaim": {
+									"type": "string",
+									"title": "Username claim",
+									"description": "Name of the identity token claim bearing the unique user identifier."
+								},
+								"usernamePrefix": {
+									"type": "string",
+									"title": "Username prefix",
+									"description": "Prefix prepended to username values to prevent clashes with existing names."
+								}
+							}
+						}
+					},
+					"title": "Control plane",
 					"type": "object"
 				}
             }

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -12,6 +12,25 @@
 			},
 			"type": "array",
 			"minItems": 1
+		},
+		"featureGate": {
+			"type": "object",
+			"title": "Feature gate",
+			"additionalProperties": false,
+			"properties": {
+				"enabled": {
+					"type": "boolean",
+					"title": "Enabled"
+				},
+				"name": {
+					"type": "string",
+					"title": "Name",
+					"examples": [
+						"UserNamespacesStatelessPodsSupport"
+					],
+					"pattern": "^[A-Za-z0-9]+$"
+				}
+			}
 		}
 	},
 	"properties": {
@@ -494,6 +513,15 @@
 						"ValidatingAdmissionWebhook"
 					]
 				},
+				"featureGates": {
+					"type": "array",
+					"title": "Feature gates",
+					"description": "API server feature gate activation/deactivation.",
+					"items": {
+						"$ref": "#/$defs/featureGate"
+					},
+					"default": []
+				}
 				"ciliumNetworkPolicy": {
 					"type": "object",
 					"title": "CiliumNetworkPolicies",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -50,53 +50,6 @@
 			"title": "Cluster",
 			"type": "object"
 		},
-		"apiServer": {
-			"properties": {
-				"certSANs": {
-					"default": [],
-					"description": "Alternative names to encode in the API server's certificate.",
-					"items": {
-						"title": "SAN",
-						"type": "string"
-					},
-					"title": "Subject alternative names (SAN)",
-					"type": "array"
-				},
-				"enableAdmissionPlugins": {
-					"default": "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook",
-					"description": "Comma-separated list of admission plugins to enable.",
-					"title": "Admission plugins",
-					"type": "string"
-				},
-				"featureGates": {
-					"default": "",
-					"description": "Enabled feature gates, as a comma-separated list.",
-					"title": "Feature gates",
-					"type": "string"
-				}
-			},
-			"required": [
-				"enableAdmissionPlugins",
-				"featureGates"
-			],
-			"title": "Kubernetes API server",
-			"type": "object"
-		},
-		"controllerManager": {
-			"properties": {
-				"featureGates": {
-					"default": "",
-					"description": "Enabled feature gates, as a comma-separated list.",
-					"title": "Feature gates",
-					"type": "string"
-				}
-			},
-			"required": [
-				"featureGates"
-			],
-			"title": "Kubernetes Controller Manager",
-			"type": "object"
-		},
 		"global": {
 			"type": "object",
 			"title": "Global parameters",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -591,36 +591,6 @@
 				}
 			}
 		},
-		"kubeadm": {
-			"properties": {
-				"users": {
-					"items": {
-						"properties": {
-							"authorizedKeys": {
-								"items": {
-									"title": "Key",
-									"type": "string"
-								},
-								"title": "Authorized keys",
-								"type": "array"
-							},
-							"name": {
-								"title": "Name",
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					"title": "Users",
-					"type": "array"
-				}
-			},
-			"title": "Kubeadm",
-			"type": [
-				"null",
-				"object"
-			]
-		},
 		"kubectlImage": {
 			"description": "Used by cluster-shared library chart to configure coredns in-cluster.",
 			"properties": {
@@ -635,58 +605,6 @@
 				}
 			},
 			"title": "Kubectl image",
-			"type": "object"
-		},
-		"template": {
-			"description": "Provisioning options for node templates.",
-			"properties": {
-				"cloneMode": {
-					"description": "Method used to clone template image.",
-					"title": "Clone mode",
-					"type": "string"
-				},
-				"diskGiB": {
-					"description": "Node disk size in GB. Must be at least as large as the source image.",
-					"title": "Disk size (GB)",
-					"type": "integer"
-				},
-				"folder": {
-					"description": "VSphere folder to deploy instances in. Must already exist.",
-					"title": "Folder",
-					"type": "string"
-				},
-				"memoryMiB": {
-					"description": "Node memory allocation in MB.",
-					"title": "Memory (MB)",
-					"type": "integer"
-				},
-				"networkName": {
-					"description": "Segment name to attach nodes to. Must already exist.",
-					"title": "Segment name",
-					"type": "string"
-				},
-				"numCPUs": {
-					"description": "Number of CPUs to assign per node.",
-					"title": "CPU cores",
-					"type": "integer"
-				},
-				"resourcePool": {
-					"description": "Resource pool to allocate nodes from. Must already exist.",
-					"title": "Resource pool",
-					"type": "string"
-				},
-				"storagePolicyName": {
-					"description": "Storage policy to use. If specified, it must already exist.",
-					"title": "Storage policy",
-					"type": "string"
-				},
-				"templateName": {
-					"description": "Image template name to use for nodes.",
-					"title": "Name",
-					"type": "string"
-				}
-			},
-			"title": "Node template",
 			"type": "object"
 		},
 		"vcenter": {
@@ -734,16 +652,6 @@
 				}
 			},
 			"title": "VCenter",
-			"type": "object"
-		},
-		"worker": {
-			"properties": {
-				"replicas": {
-					"title": "Number of nodes",
-					"type": "integer"
-				}
-			},
-			"title": "Worker",
 			"type": "object"
 		}
 	},

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -34,17 +34,6 @@
 		}
 	},
 	"properties": {
-		"cluster": {
-			"properties": {
-				"enableEncryptionProvider": {
-					"title": "API server encryption at REST",
-					"description": "Enable encryption at REST feature of API server.",
-					"type": "boolean"
-				}
-			},
-			"title": "Cluster",
-			"type": "object"
-		},
 		"global": {
 			"type": "object",
 			"title": "Global parameters",
@@ -528,6 +517,11 @@
 							"default": []
 						}
 					}
+				},
+				"enableEncryptionProvider": {
+					"title": "API server encryption at REST",
+					"description": "Enable encryption at REST feature of API server.",
+					"type": "boolean"
 				},
 				"kubernetesVersion": {
 					"type": "string",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -190,6 +190,11 @@
 				},
 				"connectivity": {
 					"properties": {
+						"baseDomain": {
+							"type": "string",
+							"title": "Base DNS domain",
+							"default": "k8s.test"
+						},
 						"network": {
 							"properties": {
 								"containerRegistries": {

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -450,6 +450,58 @@
 								}
 							}
 						}
+					},
+					"providerSpecific": {
+						"type": "object",
+						"properties": {
+							"vcenter": {
+								"description": "Configuration for vSphere API access.",
+								"properties": {
+									"datacenter": {
+										"description": "Name of the datacenter to deploy nodes into.",
+										"title": "Datacenter",
+										"type": "string"
+									},
+									"datastore": {
+										"description": "Name of the datastore for node disk storage.",
+										"title": "Datastore",
+										"type": "string"
+									},
+									"server": {
+										"description": "URL of the VSphere API.",
+										"title": "Server",
+										"type": "string"
+									},
+									"username": {
+										"description": "Username for the VSphere API.",
+										"title": "Username",
+										"type": "string"
+									},
+									"password": {
+										"description": "Password for the VSphere API.",
+										"title": "Password",
+										"type": "string"
+									},
+									"thumbprint": {
+										"description": "TLS certificate signature of the VSphere API.",
+										"title": "Thumbprint",
+										"type": "string"
+									},
+									"region": {
+										"description": "Category name in VSphere for topology.kubernetes.io/region labels.",
+										"title": "Region",
+										"type": "string"
+									},
+									"zone": {
+										"description": "Category name in VSphere for topology.kubernetes.io/zone labels.",
+										"title": "Zone",
+										"type": "string"
+									}
+								},
+								"title": "VCenter",
+								"type": "object"
+							}
+						}
 					}
 				}
 			}
@@ -605,53 +657,6 @@
 				}
 			},
 			"title": "Kubectl image",
-			"type": "object"
-		},
-		"vcenter": {
-			"description": "Configuration for vSphere API access.",
-			"properties": {
-				"datacenter": {
-					"description": "Name of the datacenter to deploy nodes into.",
-					"title": "Datacenter",
-					"type": "string"
-				},
-				"datastore": {
-					"description": "Name of the datastore for node disk storage.",
-					"title": "Datastore",
-					"type": "string"
-				},
-				"server": {
-					"description": "URL of the VSphere API.",
-					"title": "Server",
-					"type": "string"
-				},
-				"username": {
-					"description": "Username for the VSphere API.",
-					"title": "Username",
-					"type": "string"
-				},
-				"password": {
-					"description": "Password for the VSphere API.",
-					"title": "Password",
-					"type": "string"
-				},
-				"thumbprint": {
-					"description": "TLS certificate signature of the VSphere API.",
-					"title": "Thumbprint",
-					"type": "string"
-				},
-				"region": {
-					"description": "Category name in VSphere for topology.kubernetes.io/region labels.",
-					"title": "Region",
-					"type": "string"
-				},
-				"zone": {
-					"description": "Category name in VSphere for topology.kubernetes.io/zone labels.",
-					"title": "Zone",
-					"type": "string"
-				}
-			},
-			"title": "VCenter",
 			"type": "object"
 		}
 	},

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -534,6 +534,22 @@
 						}
 					}
 				},
+				"controllerManager": {
+					"type": "object",
+					"title": "Controller manager",
+					"additionalProperties": false,
+					"properties": {
+						"featureGates": {
+							"type": "array",
+							"title": "Feature gates",
+							"description": "Controller manager feature gate activation/deactivation.",
+							"items": {
+								"$ref": "#/$defs/featureGate"
+							},
+							"default": []
+						}
+					}
+				},
 				"teleport": {
 					"type": "object",
 					"title": "Teleport",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -140,155 +140,6 @@
 			"title": "Control plane",
 			"type": "object"
 		},
-		"connectivity": {
-			"properties": {
-				"network": {
-					"properties": {
-						"containerRegistries": {
-							"type": "object",
-							"title": "Container registries",
-							"description": "Endpoints and credentials configuration for container registries.",
-							"additionalProperties": {
-								"type": "array",
-								"items": {
-									"type": "object",
-									"required": [
-										"endpoint"
-									],
-									"additionalProperties": false,
-									"properties": {
-										"credentials": {
-											"type": "object",
-											"title": "Credentials",
-											"description": "Credentials for the endpoint.",
-											"additionalProperties": false,
-											"properties": {
-												"auth": {
-													"type": "string",
-													"title": "Auth",
-													"description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
-												},
-												"identitytoken": {
-													"type": "string",
-													"title": "Identity token",
-													"description": "Used to authenticate the user and obtain an access token for the registry."
-												},
-												"password": {
-													"type": "string",
-													"title": "Password",
-													"description": "Used to authenticate for the registry with username/password."
-												},
-												"username": {
-													"type": "string",
-													"title": "Username",
-													"description": "Used to authenticate for the registry with username/password."
-												}
-											}
-										},
-										"endpoint": {
-											"type": "string",
-											"title": "Endpoint",
-											"description": "Endpoint for the container registry."
-										}
-									}
-								}
-							},
-							"default": {}
-						},
-						"controlPlaneEndpoint": {
-							"description": "Kubernetes API configuration.",
-							"properties": {
-								"host": {
-									"title": "Host",
-									"description": "IP for access to the Kubernetes API. Manually select an IP for kube API. Empty string for auto selection from the ipPoolName pool.",
-									"type": "string"
-								},
-								"port": {
-									"title": "Port number",
-									"description": "Port for access to the Kubernetes API.",
-									"type": "integer"
-								},
-								"ipPoolName": {
-									"title": "Ip Pool Name",
-									"description": "Ip for control plane will be drawn from this GlobalInClusterIPPool resource.",
-									"type": "string",
-									"pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
-									"default": "wc-cp-ips"
-								}
-							},
-							"title": "Endpoint",
-							"type": "object"
-						},
-						"pods": {
-							"properties": {
-								"cidrBlocks": {
-									"$ref": "#/$defs/cidrBlocks",
-									"default": "10.244.0.0/16",
-									"title": "Pod subnets"
-								}
-							},
-							"required": [
-								"cidrBlocks"
-							],
-							"title": "Pods",
-							"type": "object"
-						},
-						"services": {
-							"properties": {
-								"cidrBlocks": {
-									"$ref": "#/$defs/cidrBlocks",
-									"default": "172.31.0.0/16",
-									"title": "Service subnets"
-								}
-							},
-							"required": [
-								"cidrBlocks"
-							],
-							"title": "Services",
-							"type": "object"
-						},
-						"loadBalancers": {
-							"anyOf": [
-								{
-									"properties": {
-										"cidrBlocks": {
-											"$ref": "#/$defs/cidrBlocks",
-											"title": "Load Balancer subnets"
-										}
-									},
-									"required": ["cidrBlocks"]
-								},
-								{
-									"properties": {
-										"ipPoolName": {
-											"title": "Ip Pool Name",
-											"description": "Ip for Service LB running in WC will be drawn from this GlobalInClusterIPPool resource.",
-											"type": "string",
-											"pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
-										}
-									},
-									"required": ["ipPoolName"]
-								}
-							],
-							"title": "Load balancers",
-							"type": "object"
-						}
-					},
-					"required": [
-						"pods",
-						"services",
-						"loadBalancers"
-					],
-					"title": "Network",
-					"type": "object"
-				}
-			},
-			"required": [
-				"network"
-			],
-			"title": "Connectivity",
-			"type": "object"
-		},
         "global": {
             "type": "object",
             "title": "Global parameters",
@@ -336,6 +187,155 @@
 							"default": false
 						}
 					}
+				},
+				"connectivity": {
+					"properties": {
+						"network": {
+							"properties": {
+								"containerRegistries": {
+									"type": "object",
+									"title": "Container registries",
+									"description": "Endpoints and credentials configuration for container registries.",
+									"additionalProperties": {
+										"type": "array",
+										"items": {
+											"type": "object",
+											"required": [
+												"endpoint"
+											],
+											"additionalProperties": false,
+											"properties": {
+												"credentials": {
+													"type": "object",
+													"title": "Credentials",
+													"description": "Credentials for the endpoint.",
+													"additionalProperties": false,
+													"properties": {
+														"auth": {
+															"type": "string",
+															"title": "Auth",
+															"description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
+														},
+														"identitytoken": {
+															"type": "string",
+															"title": "Identity token",
+															"description": "Used to authenticate the user and obtain an access token for the registry."
+														},
+														"password": {
+															"type": "string",
+															"title": "Password",
+															"description": "Used to authenticate for the registry with username/password."
+														},
+														"username": {
+															"type": "string",
+															"title": "Username",
+															"description": "Used to authenticate for the registry with username/password."
+														}
+													}
+												},
+												"endpoint": {
+													"type": "string",
+													"title": "Endpoint",
+													"description": "Endpoint for the container registry."
+												}
+											}
+										}
+									},
+									"default": {}
+								},
+								"controlPlaneEndpoint": {
+									"description": "Kubernetes API configuration.",
+									"properties": {
+										"host": {
+											"title": "Host",
+											"description": "IP for access to the Kubernetes API. Manually select an IP for kube API. Empty string for auto selection from the ipPoolName pool.",
+											"type": "string"
+										},
+										"port": {
+											"title": "Port number",
+											"description": "Port for access to the Kubernetes API.",
+											"type": "integer"
+										},
+										"ipPoolName": {
+											"title": "Ip Pool Name",
+											"description": "Ip for control plane will be drawn from this GlobalInClusterIPPool resource.",
+											"type": "string",
+											"pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+											"default": "wc-cp-ips"
+										}
+									},
+									"title": "Endpoint",
+									"type": "object"
+								},
+								"pods": {
+									"properties": {
+										"cidrBlocks": {
+											"$ref": "#/$defs/cidrBlocks",
+											"default": "10.244.0.0/16",
+											"title": "Pod subnets"
+										}
+									},
+									"required": [
+										"cidrBlocks"
+									],
+									"title": "Pods",
+									"type": "object"
+								},
+								"services": {
+									"properties": {
+										"cidrBlocks": {
+											"$ref": "#/$defs/cidrBlocks",
+											"default": "172.31.0.0/16",
+											"title": "Service subnets"
+										}
+									},
+									"required": [
+										"cidrBlocks"
+									],
+									"title": "Services",
+									"type": "object"
+								},
+								"loadBalancers": {
+									"anyOf": [
+										{
+											"properties": {
+												"cidrBlocks": {
+													"$ref": "#/$defs/cidrBlocks",
+													"title": "Load Balancer subnets"
+												}
+											},
+											"required": ["cidrBlocks"]
+										},
+										{
+											"properties": {
+												"ipPoolName": {
+													"title": "Ip Pool Name",
+													"description": "Ip for Service LB running in WC will be drawn from this GlobalInClusterIPPool resource.",
+													"type": "string",
+													"pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+												}
+											},
+											"required": ["ipPoolName"]
+										}
+									],
+									"title": "Load balancers",
+									"type": "object"
+								}
+							},
+							"required": [
+								"pods",
+								"services",
+								"loadBalancers"
+							],
+							"title": "Network",
+							"type": "object"
+						}
+					},
+					"required": [
+						"network"
+					],
+					"title": "Connectivity",
+					"type": "object"
 				}
             }
         },

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -468,6 +468,32 @@
 			"type": "object",
 			"additionalProperties": false,
 			"properties": {
+				"enableAdmissionPlugins": {
+					"type": "array",
+					"title": "Admission plugins",
+					"description": "List of admission plugins to be passed to the API server via the --enable-admission-plugins flag.",
+					"items": {
+						"type": "string",
+						"title": "Plugin",
+						"examples": [
+							"DefaultStorageClass",
+							"Priority"
+						],
+						"pattern": "^[A-Za-z0-9]+$"
+					},
+					"default": [
+						"DefaultStorageClass",
+						"DefaultTolerationSeconds",
+						"LimitRanger",
+						"MutatingAdmissionWebhook",
+						"NamespaceLifecycle",
+						"PersistentVolumeClaimResize",
+						"Priority",
+						"ResourceQuota",
+						"ServiceAccount",
+						"ValidatingAdmissionWebhook"
+					]
+				},
 				"ciliumNetworkPolicy": {
 					"type": "object",
 					"title": "CiliumNetworkPolicies",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -513,6 +513,16 @@
 						"ValidatingAdmissionWebhook"
 					]
 				},
+				"certSANs": {
+					"default": [],
+					"description": "Alternative names to encode in the API server's certificate.",
+					"items": {
+						"title": "SAN",
+						"type": "string"
+					},
+					"title": "Subject alternative names (SAN)",
+					"type": "array"
+				},
 				"featureGates": {
 					"type": "array",
 					"title": "Feature gates",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -78,22 +78,22 @@
 			"title": "Kubernetes Controller Manager",
 			"type": "object"
 		},
-        "global": {
-            "type": "object",
-            "title": "Global parameters",
-            "properties": {
-                "podSecurityStandards": {
-                    "type": "object",
-                    "title": "Pod Security Standards",
-                    "properties": {
-                        "enforced": {
-                            "type": "boolean",
-                            "title": "Enforced Pod Security Standards",
-                            "description": "Use PSSs instead of PSPs.",
-                            "default": true
-                        }
-                    }
-                },
+		"global": {
+			"type": "object",
+			"title": "Global parameters",
+			"properties": {
+				"podSecurityStandards": {
+					"type": "object",
+					"title": "Pod Security Standards",
+					"properties": {
+						"enforced": {
+							"type": "boolean",
+							"title": "Enforced Pod Security Standards",
+							"description": "Use PSSs instead of PSPs.",
+							"default": true
+						}
+					}
+				},
 				"metadata": {
 					"type": "object",
 					"title": "Metadata",
@@ -272,6 +272,31 @@
 							],
 							"title": "Network",
 							"type": "object"
+						},
+						"shell": {
+							"type": "object",
+							"properties": {
+								"osUsers": {
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"name": {
+												"type": "string"
+											},
+											"sudo": {
+												"type": "string"
+											}
+										}
+									}
+								},
+								"sshTrustedUserCAKeys": {
+									"type": "array",
+									"items": {
+										"type": "string"
+									}
+								}
+							}
 						}
 					},
 					"required": [
@@ -437,8 +462,8 @@
 						}
 					}
 				}
-            }
-        },
+			}
+		},
 		"internal": {
 			"type": "object",
 			"additionalProperties": false,

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -389,6 +389,53 @@
 					},
 					"title": "Control plane",
 					"type": "object"
+				},
+				"nodePools": {
+					"type": "object",
+					"title": "Node pools",
+					"description": "Groups of worker nodes with identical configuration.",
+					"additionalProperties": false,
+					"patternProperties": {
+						"^[a-z0-9-]{3,10}$": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"class": {
+									"type": "string",
+									"title": "Node class",
+									"description": "A valid node class name.",
+									"pattern": "^[a-z0-9-]+$"
+								},
+								"replicas": {
+									"type": "integer",
+									"title": "Number of nodes",
+									"default": 1,
+									"minimum": 1
+								}
+							}
+						}
+					},
+					"properties": {
+						"worker": {
+							"type": "object",
+							"title": "Default nodePool",
+							"additionalProperties": false,
+							"properties": {
+								"class": {
+									"type": "string",
+									"title": "Node class",
+									"description": "A valid node class name.",
+									"default": "default"
+								},
+								"replicas": {
+									"type": "integer",
+									"title": "Number of nodes",
+									"default": 2,
+									"minimum": 1
+								}
+							}
+						}
+					}
 				}
             }
         },

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -63,38 +63,6 @@
 			"title": "Kubernetes API server",
 			"type": "object"
 		},
-		"metadata": {
-			"type": "object",
-			"title": "Metadata",
-			"additionalProperties": false,
-			"properties": {
-				"description": {
-					"type": "string",
-					"title": "Cluster description",
-					"description": "User-friendly description of the cluster's purpose."
-				},
-				"labels": {
-					"type": "object",
-					"title": "Labels",
-					"description": "These labels are added to the Kubernetes resources defining this cluster.",
-					"additionalProperties": false,
-					"patternProperties": {
-						"^[a-zA-Z0-9/\\._-]+$": {
-							"type": "string",
-							"title": "Label",
-							"maxLength": 63,
-							"minLength": 0,
-							"pattern": "^[a-zA-Z0-9\\._-]+$"
-						}
-					}
-				},
-				"preventDeletion": {
-					"type": "boolean",
-					"title": "Prevent cluster deletion",
-					"default": false
-				}
-			}
-		},
 		"controllerManager": {
 			"properties": {
 				"featureGates": {
@@ -321,6 +289,56 @@
 			"title": "Connectivity",
 			"type": "object"
 		},
+        "global": {
+            "type": "object",
+            "title": "Global parameters",
+            "properties": {
+                "podSecurityStandards": {
+                    "type": "object",
+                    "title": "Pod Security Standards",
+                    "properties": {
+                        "enforced": {
+                            "type": "boolean",
+                            "title": "Enforced Pod Security Standards",
+                            "description": "Use PSSs instead of PSPs.",
+                            "default": true
+                        }
+                    }
+                },
+				"metadata": {
+					"type": "object",
+					"title": "Metadata",
+					"additionalProperties": false,
+					"properties": {
+						"description": {
+							"type": "string",
+							"title": "Cluster description",
+							"description": "User-friendly description of the cluster's purpose."
+						},
+						"labels": {
+							"type": "object",
+							"title": "Labels",
+							"description": "These labels are added to the Kubernetes resources defining this cluster.",
+							"additionalProperties": false,
+							"patternProperties": {
+								"^[a-zA-Z0-9/\\._-]+$": {
+									"type": "string",
+									"title": "Label",
+									"maxLength": 63,
+									"minLength": 0,
+									"pattern": "^[a-zA-Z0-9\\._-]+$"
+								}
+							}
+						},
+						"preventDeletion": {
+							"type": "boolean",
+							"title": "Prevent cluster deletion",
+							"default": false
+						}
+					}
+				}
+            }
+        },
 		"internal": {
 			"type": "object",
 			"additionalProperties": false,

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -456,51 +456,56 @@
 			"type": "object",
 			"additionalProperties": false,
 			"properties": {
-				"enableAdmissionPlugins": {
-					"type": "array",
-					"title": "Admission plugins",
-					"description": "List of admission plugins to be passed to the API server via the --enable-admission-plugins flag.",
-					"items": {
-						"type": "string",
-						"title": "Plugin",
-						"examples": [
-							"DefaultStorageClass",
-							"Priority"
-						],
-						"pattern": "^[A-Za-z0-9]+$"
-					},
-					"default": [
-						"DefaultStorageClass",
-						"DefaultTolerationSeconds",
-						"LimitRanger",
-						"MutatingAdmissionWebhook",
-						"NamespaceLifecycle",
-						"PersistentVolumeClaimResize",
-						"Priority",
-						"ResourceQuota",
-						"ServiceAccount",
-						"ValidatingAdmissionWebhook"
-					]
-				},
-				"certSANs": {
-					"default": [],
-					"description": "Alternative names to encode in the API server's certificate.",
-					"items": {
-						"title": "SAN",
-						"type": "string"
-					},
-					"title": "Subject alternative names (SAN)",
-					"type": "array"
-				},
-				"featureGates": {
-					"type": "array",
-					"title": "Feature gates",
-					"description": "API server feature gate activation/deactivation.",
-					"items": {
-						"$ref": "#/$defs/featureGate"
-					},
-					"default": []
-				},
+				"apiServer": {
+                    "type": "object",
+                    "properties": {
+                        "enableAdmissionPlugins": {
+							"type": "array",
+							"title": "Admission plugins",
+							"description": "List of admission plugins to be passed to the API server via the --enable-admission-plugins flag.",
+							"items": {
+								"type": "string",
+								"title": "Plugin",
+								"examples": [
+									"DefaultStorageClass",
+									"Priority"
+								],
+								"pattern": "^[A-Za-z0-9]+$"
+							},
+							"default": [
+								"DefaultStorageClass",
+								"DefaultTolerationSeconds",
+								"LimitRanger",
+								"MutatingAdmissionWebhook",
+								"NamespaceLifecycle",
+								"PersistentVolumeClaimResize",
+								"Priority",
+								"ResourceQuota",
+								"ServiceAccount",
+								"ValidatingAdmissionWebhook"
+							]
+						},
+						"certSANs": {
+							"default": [],
+							"description": "Alternative names to encode in the API server's certificate.",
+							"items": {
+								"title": "SAN",
+								"type": "string"
+							},
+							"title": "Subject alternative names (SAN)",
+							"type": "array"
+						},
+						"featureGates": {
+							"type": "array",
+							"title": "Feature gates",
+							"description": "API server feature gate activation/deactivation.",
+							"items": {
+								"$ref": "#/$defs/featureGate"
+							},
+							"default": []
+						}
+					}
+                },		
 				"ciliumNetworkPolicy": {
 					"type": "object",
 					"title": "CiliumNetworkPolicies",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -36,11 +36,6 @@
 	"properties": {
 		"cluster": {
 			"properties": {
-				"kubernetesVersion": {
-					"title": "Kubernetes version",
-					"description": "Kubernetes version to deploy. Must match the version available in the image defined at template.",
-					"type": "string"
-				},
 				"enableEncryptionProvider": {
 					"title": "API server encryption at REST",
 					"description": "Enable encryption at REST feature of API server.",
@@ -533,6 +528,12 @@
 							"default": []
 						}
 					}
+				},
+				"kubernetesVersion": {
+					"type": "string",
+					"title": "Kubernetes version",
+					"description": "Kubernetes version to deploy. Must match the version available in the image defined at template.",
+					"default": "v1.25.16"
 				},
 				"teleport": {
 					"type": "object",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -91,10 +91,26 @@
 								}
 							}
 						},
+						"organization": {
+							 "type": "string",
+							  "title": "Organization"
+						},
 						"preventDeletion": {
 							"type": "boolean",
 							"title": "Prevent cluster deletion",
 							"default": false
+						},
+						"servicePriority": {
+							"type": "string",
+							"title": "Service priority",
+							"description": "The relative importance of this cluster.",
+							"$comment": "Defined in https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority",
+							"enum": [
+								"highest",
+								"medium",
+								"lowest"
+							],
+							"default": "highest"
 						}
 					}
 				},
@@ -484,7 +500,7 @@
 						"$ref": "#/$defs/featureGate"
 					},
 					"default": []
-				}
+				},
 				"ciliumNetworkPolicy": {
 					"type": "object",
 					"title": "CiliumNetworkPolicies",
@@ -602,11 +618,6 @@
 			},
 			"title": "Kubectl image",
 			"type": "object"
-		},
-		"organization": {
-			"title": "Organization",
-			"description": "The organization which owns this cluster",
-			"type": "string"
 		},
 		"template": {
 			"description": "Provisioning options for node templates.",

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -65,6 +65,16 @@ global:
       replicas: 2
   podSecurityStandards:
     enforced: true
+  providerSpecific:
+    vcenter:
+      datacenter: ""
+      username: ""
+      password: ""
+      datastore: ""
+      server: ""
+      thumbprint: ""
+      region: ""
+      zone: ""
 
 internal:
   apiServer:
@@ -115,12 +125,3 @@ nodeClasses:
         dhcp4: true
 
 
-vcenter:
-  datacenter: ""
-  username: ""
-  password: ""
-  datastore: ""
-  server: ""
-  thumbprint: ""
-  region: ""
-  zone: ""

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -64,6 +64,10 @@ global:
       groupsPrefix: ""
   metadata:
     preventDeletion: false
+  nodePools:
+    worker:
+      class: default
+      replicas: 2
   podSecurityStandards:
     enforced: true
 
@@ -96,11 +100,6 @@ nodeClasses:
       devices:
       - networkName: ""
         dhcp4: true
-
-nodePools:
-  worker:
-    class: default
-    replicas: 2
 
 organization: ""
 

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -1,6 +1,3 @@
-cluster:
-  enableEncryptionProvider: true
-
 global:
   connectivity:
     baseDomain: k8s.test
@@ -87,6 +84,7 @@ internal:
     enabled: true
   controllerManager:
     featureGates: []
+  enableEncryptionProvider: true
   kubernetesVersion: "v1.25.16"
   teleport:
     proxyAddr: teleport.giantswarm.io:443

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -32,6 +32,12 @@ global:
         cidrBlocks:
         - "172.31.0.0/16"
     containerRegistries: {}
+    shell:
+      osUsers:
+        - name: "giantswarm"
+          sudo: "ALL=(ALL) NOPASSWD:ALL"
+      sshTrustedUserCAKeys:
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
   controlPlane:
     replicas: 1
     machineTemplate:
@@ -103,18 +109,12 @@ nodeClasses:
 
 organization: ""
 
-osUsers:
-- name: "giantswarm"
-  sudo: "ALL=(ALL) NOPASSWD:ALL"
-
 proxy:
   secretName: ""
   enabled: false
 
 servicePriority: "highest"
 
-sshTrustedUserCAKeys:
-  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
 
 vcenter:
   datacenter: ""

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -1,5 +1,4 @@
 apiServer:
-  featureGates: ""
   certSANs: []
 
 cluster:
@@ -89,6 +88,7 @@ internal:
       - ResourceQuota
       - ServiceAccount
       - ValidatingAdmissionWebhook
+  featureGates: []
   ciliumNetworkPolicy:
     enabled: true
   teleport:

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -14,29 +14,6 @@ clusterLabels: {}
 controllerManager:
   featureGates: ""
 
-controlPlane:
-  replicas: 1
-  machineTemplate:
-    cloneMode: "linkedClone"
-    diskGiB: 50
-    numCPUs: 4
-    template: "flatcar-stable-3602.2.1-kube-v1.25.16-gs"
-    resourcePool: "*/Resources"
-    memoryMiB: 8192
-    network:
-      devices:
-      - dhcp4: true
-        networkName: ""
-  etcd:
-    imageRepository: "gsoci.azurecr.io/giantswarm"
-    imageTag: 3.5.4-0-k8s
-  dns:
-    imageRepository: "gsoci.azurecr.io/giantswarm"
-    imageTag: 1.9.4-giantswarm
-  image:
-    repository: gsoci.azurecr.io/giantswarm
-  resourceRatio: 8
-
 global:
   connectivity:
     baseDomain: k8s.test
@@ -55,6 +32,36 @@ global:
         cidrBlocks:
         - "172.31.0.0/16"
     containerRegistries: {}
+  controlPlane:
+    replicas: 1
+    machineTemplate:
+      cloneMode: "linkedClone"
+      diskGiB: 50
+      numCPUs: 4
+      template: "flatcar-stable-3602.2.1-kube-v1.25.16-gs"
+      resourcePool: "*/Resources"
+      memoryMiB: 8192
+      network:
+        devices:
+        - dhcp4: true
+          networkName: ""
+    etcd:
+      imageRepository: "gsoci.azurecr.io/giantswarm"
+      imageTag: 3.5.4-0-k8s
+    dns:
+      imageRepository: "gsoci.azurecr.io/giantswarm"
+      imageTag: 1.9.4-giantswarm
+    image:
+      repository: gsoci.azurecr.io/giantswarm
+    resourceRatio: 8
+    oidc:
+      issuerUrl: ""
+      caFile: ""
+      clientId: ""
+      usernameClaim: ""
+      groupsClaim: ""
+      usernamePrefix: ""
+      groupsPrefix: ""
   metadata:
     preventDeletion: false
   podSecurityStandards:
@@ -94,14 +101,6 @@ nodePools:
   worker:
     class: default
     replicas: 2
-
-oidc:
-  issuerUrl: ""
-  caFile: ""
-  clientId: ""
-  usernameClaim: ""
-  groupsClaim: ""
-  usernamePrefix: ""
 
 organization: ""
 

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -57,6 +57,8 @@ controlPlane:
 global:
   podSecurityStandards:
     enforced: true
+  metadata:
+    preventDeletion: false
 
 internal:
   ciliumNetworkPolicy:
@@ -74,9 +76,6 @@ kubectlImage:
   registry: gsoci.azurecr.io
   name: giantswarm/kubectl
   tag: 1.23.5
-
-metadata:
-  preventDeletion: false
 
 nodeClasses:
   default:

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -9,8 +9,6 @@ clusterDescription: ""
 
 clusterLabels: {}
 
-controllerManager:
-  featureGates: ""
 
 global:
   connectivity:
@@ -91,6 +89,8 @@ internal:
   featureGates: []
   ciliumNetworkPolicy:
     enabled: true
+  controllerManager:
+    featureGates: []
   teleport:
     proxyAddr: teleport.giantswarm.io:443
     version: 14.1.3

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -1,5 +1,4 @@
 apiServer:
-  enableAdmissionPlugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"
   featureGates: ""
   certSANs: []
 
@@ -78,6 +77,18 @@ global:
     enforced: true
 
 internal:
+  apiServer:
+    enableAdmissionPlugins:
+      - DefaultStorageClass
+      - DefaultTolerationSeconds
+      - LimitRanger
+      - MutatingAdmissionWebhook
+      - NamespaceLifecycle
+      - PersistentVolumeClaimResize
+      - Priority
+      - ResourceQuota
+      - ServiceAccount
+      - ValidatingAdmissionWebhook
   ciliumNetworkPolicy:
     enabled: true
   teleport:

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -16,6 +16,7 @@ global:
         cidrBlocks:
         - "172.31.0.0/16"
     containerRegistries: {}
+    proxy: {}
     shell:
       osUsers:
         - name: "giantswarm"
@@ -113,10 +114,6 @@ nodeClasses:
       - networkName: ""
         dhcp4: true
 
-
-proxy:
-  secretName: ""
-  enabled: false
 
 vcenter:
   datacenter: ""

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -39,6 +39,7 @@ controlPlane:
 
 global:
   connectivity:
+    baseDomain: k8s.test
     network:
       controlPlaneEndpoint:
         host: ""

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -2,11 +2,6 @@ cluster:
   kubernetesVersion: "v1.25.16"
   enableEncryptionProvider: true
 
-clusterDescription: ""
-
-clusterLabels: {}
-
-
 global:
   connectivity:
     baseDomain: k8s.test
@@ -62,7 +57,11 @@ global:
       usernamePrefix: ""
       groupsPrefix: ""
   metadata:
+    description: ""
+    labels: {}
+    organization: ""
     preventDeletion: false
+    servicePriority: "highest"
   nodePools:
     worker:
       class: default
@@ -116,14 +115,10 @@ nodeClasses:
       - networkName: ""
         dhcp4: true
 
-organization: ""
 
 proxy:
   secretName: ""
   enabled: false
-
-servicePriority: "highest"
-
 
 vcenter:
   datacenter: ""

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -1,6 +1,3 @@
-apiServer:
-  certSANs: []
-
 cluster:
   kubernetesVersion: "v1.25.16"
   enableEncryptionProvider: true
@@ -86,6 +83,7 @@ internal:
       - ResourceQuota
       - ServiceAccount
       - ValidatingAdmissionWebhook
+  certSANs: []
   featureGates: []
   ciliumNetworkPolicy:
     enabled: true

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -82,8 +82,8 @@ internal:
       - ResourceQuota
       - ServiceAccount
       - ValidatingAdmissionWebhook
-  certSANs: []
-  featureGates: []
+    certSANs: []
+    featureGates: []
   ciliumNetworkPolicy:
     enabled: true
   controllerManager:

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -1,5 +1,4 @@
 cluster:
-  kubernetesVersion: "v1.25.16"
   enableEncryptionProvider: true
 
 global:
@@ -88,6 +87,7 @@ internal:
     enabled: true
   controllerManager:
     featureGates: []
+  kubernetesVersion: "v1.25.16"
   teleport:
     proxyAddr: teleport.giantswarm.io:443
     version: 14.1.3

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -11,23 +11,6 @@ clusterDescription: ""
 
 clusterLabels: {}
 
-connectivity:
-  network:
-    controlPlaneEndpoint:
-      host: ""
-      port: 6443
-      ipPoolName: "wc-cp-ips"
-    loadBalancers:
-      cidrBlocks: []
-      ipPoolName: "svc-lb-ips"
-    pods:
-      cidrBlocks:
-      - "10.244.0.0/16"
-    services:
-      cidrBlocks:
-      - "172.31.0.0/16"
-  containerRegistries: {}
-
 controllerManager:
   featureGates: ""
 
@@ -55,10 +38,26 @@ controlPlane:
   resourceRatio: 8
 
 global:
-  podSecurityStandards:
-    enforced: true
+  connectivity:
+    network:
+      controlPlaneEndpoint:
+        host: ""
+        port: 6443
+        ipPoolName: "wc-cp-ips"
+      loadBalancers:
+        cidrBlocks: []
+        ipPoolName: "svc-lb-ips"
+      pods:
+        cidrBlocks:
+        - "10.244.0.0/16"
+      services:
+        cidrBlocks:
+        - "172.31.0.0/16"
+    containerRegistries: {}
   metadata:
     preventDeletion: false
+  podSecurityStandards:
+    enforced: true
 
 internal:
   ciliumNetworkPolicy:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3372

```[tasklist]
- [x] Move `.Values.metadata` to `.Values.global.metadata`.
- [x] Move `.Values.connectivity` to `.Values.global.connectivity`.
- [x] Move `.Values.baseDomain` to `.Values.global.connectivity.baseDomain`.
- [x] Move `.Values.controlPlane` (and other control plane properties) to `.Values.global.controlPlane`.
- [x] Move `.Values.nodePools` to `.Values.global.nodePools`.
- [ ] Move remaining provider-specific Helm values to `.Values.global.providerSpecific`.
- [ ] Make sure that all Helm values that are required in cluster chart are correctly added to cluster-vsphere Helm values.
- [ ] Update cluster-vsphere e2e tests in cluster-test-suites.
- [ ] Update kubectl-gs if needed.
- [ ] Update happa if needed.
- [ ] Update relevant public docs (component-specific docs, where applicable, should be updated while working on the above tasks).
- [ ] Update all Giant Swarm CAPV clusters to the new cluster-vsphere version (first MCs then WCs).
```

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
