### PR TITLE
Remove etcd and dns images from kubeadmcontrolplane

### DIFF
--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -76,15 +76,10 @@ spec:
           terminated-pod-gc-threshold: "125"
           feature-gates: {{ .Values.controllerManager.featureGates | quote }}
           profiling: "false"
-      dns:
-        imageRepository: {{ .Values.controlPlane.dns.imageRepository }}
-        imageTag: {{ .Values.controlPlane.dns.imageTag }}
       etcd:
         local:
           extraArgs:
             listen-metrics-urls: "http://0.0.0.0:2381"
-          imageRepository: {{ .Values.controlPlane.etcd.imageRepository }}
-          imageTag: {{ .Values.controlPlane.etcd.imageTag }}
       imageRepository: {{ .Values.controlPlane.image.repository }}
       scheduler:
         extraArgs:

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -112,40 +112,6 @@
 		},
 		"controlPlane": {
 			"properties": {
-				"dns": {
-                    "type": "object",
-                    "title": "DNS container image",
-                    "additionalProperties": false,
-                    "properties": {
-                        "imageRepository": {
-                            "type": "string",
-                            "title": "Repository",
-                            "default": "gsoci.azurecr.io/giantswarm"
-                        },
-                        "imageTag": {
-                            "type": "string",
-                            "title": "Tag",
-                            "default": "1.9.4-giantswarm"
-                        }
-                    }
-                },
-                "etcd": {
-                    "type": "object",
-                    "title": "Etcd container image",
-                    "additionalProperties": false,
-                    "properties": {
-                        "imageRepository": {
-                            "type": "string",
-                            "title": "Repository",
-                            "default": "gsoci.azurecr.io/giantswarm"
-                        },
-                        "imageTag": {
-                            "type": "string",
-                            "title": "Tag",
-                            "default": "3.5.4-0-k8s"
-                        }
-                    }
-                },
                 "image": {
                     "type": "object",
                     "title": "Node container image",

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -44,12 +44,6 @@ controlPlane:
       devices:
       - dhcp4: true
         networkName: ""
-  etcd:
-    imageRepository: "gsoci.azurecr.io/giantswarm"
-    imageTag: 3.5.4-0-k8s
-  dns:
-    imageRepository: "gsoci.azurecr.io/giantswarm"
-    imageTag: 1.9.4-giantswarm
   image:
     repository: gsoci.azurecr.io/giantswarm
   resourceRatio: 8


### PR DESCRIPTION
This pr removes our ability to set etcd images (and coredns which wasn't used like that anyways). This means it will be handled automatically by kubeadm.

This also aligns with our cloud providers.

https://gigantic.slack.com/archives/CLPMFRVU6/p1712831360621509?thread_ts=1712831054.292869&cid=CLPMFRVU6

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
