### PR TITLE
refactor: aggregate connectivity values under global key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,20 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
     with(select(.organization != null);             .global.metadata.organization = .organization) |
     with(select(.clusterLabels != null);            .global.metadata.labels = .clusterLabels) |
     with(select(.servicePriority != null);          .global.metadata.servicePriority = .servicePriority) |
+    with(select(.connectivity != null);             .global.connectivity = .connectivity) |
+    with(select(.osUsers != null);                  .global.connectivity.shell.osUsers = .osUsers) |
+    with(select(.sshTrustedUserCAKeys != null);     .global.connectivity.shell.sshTrustedUserCAKeys = .sshTrustedUserCAKeys) |
+    with(select(.proxy != null);                    .global.connectivity.proxy = .proxy) |
 
     del(.metadata) |
     del(.clusterDescription) |
     del(.organization) |
     del(.clusterLabels) |
-    del(.servicePriority)' values.yaml
+    del(.servicePriority)
+    del(.connectivity) |
+    del(.osUsers) |
+    del(.sshTrustedUserCAKeys) |
+    del(.proxy)' values.yaml
 ```
 
 </details>
@@ -38,6 +46,10 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
 - Move Helm values property `.Values.organization` to `.Values.global.metadata.organization`.
 - Move Helm values property `.Values.clusterLabels` to `.Values.global.metadata.labels`.
 - Move Helm values property `.Values.servicePriority` to `.Values.global.metadata.servicePriority`.
+- Move Helm values property `.Values.connectivity` to `.Values.global.connectivity`.
+- Move Helm values property `.Values.proxy` to `.Values.global.connectivity.proxy`.
+- Move Helm values property `.Values.osUsers` to `.Values.global.connectivity.shell.osUsers`.
+- Move Helm values property `.Values.sshTrustedUserCAKeys` to `.Values.global.connectivity.shell.sshTrustedUserCAKeys`.
 
 ## [0.50.0] - 2024-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
     del(.clusterDescription) |
     del(.organization) |
     del(.clusterLabels) |
-    del(.servicePriority)
+    del(.servicePriority) |
     del(.connectivity) |
     del(.osUsers) |
     del(.sshTrustedUserCAKeys) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
     with(select(.osUsers != null);                  .global.connectivity.shell.osUsers = .osUsers) |
     with(select(.sshTrustedUserCAKeys != null);     .global.connectivity.shell.sshTrustedUserCAKeys = .sshTrustedUserCAKeys) |
     with(select(.proxy != null);                    .global.connectivity.proxy = .proxy) |
+    with(select(.baseDomain != null);               .global.connectivity.baseDomain = .baseDomain) |
 
     del(.metadata) |
     del(.clusterDescription) |
@@ -34,7 +35,8 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
     del(.connectivity) |
     del(.osUsers) |
     del(.sshTrustedUserCAKeys) |
-    del(.proxy)' values.yaml
+    del(.proxy) |
+    del(.baseDomain)' values.yaml
 ```
 
 </details>
@@ -50,6 +52,7 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
 - Move Helm values property `.Values.proxy` to `.Values.global.connectivity.proxy`.
 - Move Helm values property `.Values.osUsers` to `.Values.global.connectivity.shell.osUsers`.
 - Move Helm values property `.Values.sshTrustedUserCAKeys` to `.Values.global.connectivity.shell.sshTrustedUserCAKeys`.
+- Move Helm values property `.Values.baseDomain` to `.Values.global.connectivity.baseDomain`.
 
 ## [0.50.0] - 2024-04-23
 

--- a/helm/cluster-vsphere/ci/ci-values.yaml
+++ b/helm/cluster-vsphere/ci/ci-values.yaml
@@ -26,14 +26,6 @@ controlPlane:
       devices:
         - networkName: 'grasshopper-capv'
           dhcp4: true
-connectivity:
-  network:
-    controlPlaneEndpoint:
-      host: "10.10.222.241"
-      port: 6443
-    loadBalancers:
-      cidrBlocks:
-        - "10.10.222.224/30"
 nodeClasses:
   default:
     template: "ubuntu-2004-kube-v1.24.11"
@@ -54,3 +46,11 @@ global:
   metadata:
     description: "test cluster"
     organization: "giantswarm"
+  connectivity:
+    network:
+      controlPlaneEndpoint:
+        host: "10.10.222.241"
+        port: 6443
+      loadBalancers:
+        cidrBlocks:
+          - "10.10.222.224/30"

--- a/helm/cluster-vsphere/ci/ci-values.yaml
+++ b/helm/cluster-vsphere/ci/ci-values.yaml
@@ -1,4 +1,3 @@
-baseDomain: k8s.test
 cluster:
   name: test
   kubernetesVersion: "v1.24.11"
@@ -54,3 +53,4 @@ global:
       loadBalancers:
         cidrBlocks:
           - "10.10.222.224/30"
+    baseDomain: k8s.test

--- a/helm/cluster-vsphere/files/etc/containerd/config.toml
+++ b/helm/cluster-vsphere/files/etc/containerd/config.toml
@@ -25,7 +25,7 @@ sandbox_image = "{{ .Values.internal.sandboxContainerImage.registry }}/{{ .Value
 
 [plugins."io.containerd.grpc.v1.cri".registry]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-  {{- range $host, $config := .Values.connectivity.containerRegistries }}
+  {{- range $host, $config := .Values.global.connectivity.containerRegistries }}
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{$host}}"]
       endpoint = [
         {{- range $value := $config -}}
@@ -34,7 +34,7 @@ sandbox_image = "{{ .Values.internal.sandboxContainerImage.registry }}/{{ .Value
     ]
   {{- end }}
 [plugins."io.containerd.grpc.v1.cri".registry.configs]
-  {{ range $host, $config := .Values.connectivity.containerRegistries -}}
+  {{ range $host, $config := .Values.global.connectivity.containerRegistries -}}
     {{ range $value := $config -}}
       {{ with $value.credentials -}}
       [plugins."io.containerd.grpc.v1.cri".registry.configs."{{$value.endpoint}}".auth]

--- a/helm/cluster-vsphere/files/etc/teleport.yaml
+++ b/helm/cluster-vsphere/files/etc/teleport.yaml
@@ -25,6 +25,6 @@ ssh_service:
     ins: {{ .Values.managementCluster }}
     mc: {{ .Values.managementCluster }}
     cluster: {{ include "resource.default.name" $ }}
-    baseDomain: {{ .Values.baseDomain }}
+    baseDomain: {{ .Values.global.connectivity.baseDomain }}
 proxy_service:
   enabled: "no"

--- a/helm/cluster-vsphere/templates/_cluster_dns.tpl
+++ b/helm/cluster-vsphere/templates/_cluster_dns.tpl
@@ -8,10 +8,10 @@
     replaced with .10.
 */}}
 {{- define "clusterDNS" -}}
-    {{- $serviceCidrBlock := index .Values.connectivity.network.services.cidrBlocks 0 -}}
+    {{- $serviceCidrBlock := index .Values.global.connectivity.network.services.cidrBlocks 0 -}}
     {{- $mask := int (mustRegexReplaceAll `^.*/(\d+)$` $serviceCidrBlock "${1}") -}}
     {{- if gt $mask 24 -}}
-        {{- fail (printf ".Values.connectivity.network.services.cidrBlocks[0]=%q mask must be <= 24" $serviceCidrBlock) -}}
+        {{- fail (printf ".Values.global.connectivity.network.services.cidrBlocks[0]=%q mask must be <= 24" $serviceCidrBlock) -}}
     {{- end -}}
     {{- mustRegexReplaceAll `^(\d+\.\d+\.\d+).*$` $serviceCidrBlock "${1}.10" -}}
 {{- end -}}

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -127,14 +127,14 @@ files:
   {{- include "sshFiles" . | nindent 2}}
   {{- include "teleportFiles" . | nindent 2 }}
   {{- include "containerdConfig" . | nindent 2 }}
-  {{- if $.Values.proxy.enabled }}
+  {{- if $.Values.global.connectivity.proxy.enabled }}
     {{- include "containerdProxyConfig" . | nindent 2}}
     {{- include "teleportProxyConfig" . | nindent 2 }}
   {{- end }}
 preKubeadmCommands:
 {{ include "sshPreKubeadmCommands" . }}
 - /bin/test ! -d /var/lib/kubelet && (/bin/mkdir -p /var/lib/kubelet && /bin/chmod 0750 /var/lib/kubelet)
-  {{- if $.Values.proxy.enabled }}
+  {{- if $.Values.global.connectivity.proxy.enabled }}
 - systemctl daemon-reload
 - systemctl restart containerd
   {{- if $.Values.internal.teleport.enabled }}

--- a/helm/cluster-vsphere/templates/_ssh.tpl
+++ b/helm/cluster-vsphere/templates/_ssh.tpl
@@ -3,11 +3,11 @@
 
 
 {{- define "sshFiles" -}}
-{{- if $.Values.sshTrustedUserCAKeys -}}
+{{- if $.Values.global.connectivity.shell.sshTrustedUserCAKeys -}}
 - path: /etc/ssh/trusted-user-ca-keys.pem
   permissions: "0600"
   content: |
-    {{- range $.Values.sshTrustedUserCAKeys}}
+    {{- range $.Values.global.connectivity.shell.sshTrustedUserCAKeys}}
     {{.}}
     {{- end }}
 - path: /etc/ssh/sshd_config
@@ -22,8 +22,8 @@
 {{- end -}}
 
 {{- define "sshUsers" -}}
-{{- if $.Values.osUsers -}}
+{{- if $.Values.global.connectivity.shell.osUsers -}}
 users:
-  {{- $.Values.osUsers | toYaml | nindent 2}}
+  {{- $.Values.global.connectivity.shell.osUsers | toYaml | nindent 2}}
 {{- end }}
 {{- end -}}

--- a/helm/cluster-vsphere/templates/cluster.yaml
+++ b/helm/cluster-vsphere/templates/cluster.yaml
@@ -20,12 +20,12 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        {{- range .Values.connectivity.network.pods.cidrBlocks }}
+        {{- range .Values.global.connectivity.network.pods.cidrBlocks }}
         - {{ . }}
         {{- end }}
     services:
       cidrBlocks:
-        {{- range .Values.connectivity.network.services.cidrBlocks }}
+        {{- range .Values.global.connectivity.network.services.cidrBlocks }}
         - {{ . }}
         {{- end }}
   controlPlaneRef:

--- a/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
   values:
     ipam:
       mode: kubernetes
-    k8sServiceHost: api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}
+    k8sServiceHost: api.{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}
     k8sServicePort: "6443"
     kubeProxyReplacement: strict
     global:

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -55,7 +55,7 @@ spec:
       podSecurityStandards:
         enforced: {{ .Values.global.podSecurityStandards.enforced }}
     kube-vip-cloud-provider:
-      cidrGlobal: '{{ join "," .Values.connectivity.network.loadBalancers.cidrBlocks }}'
+      cidrGlobal: '{{ join "," .Values.global.connectivity.network.loadBalancers.cidrBlocks }}'
       image:
         repository: docker.io/giantswarm/kube-vip-cloud-provider
         tag: v0.0.4

--- a/helm/cluster-vsphere/templates/helmreleases/coredns-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/coredns-helmrelease.yaml
@@ -35,10 +35,10 @@ spec:
   values:
     cluster:
       calico:
-        CIDR: {{ index .Values.connectivity.network.pods.cidrBlocks 0 | quote }}
+        CIDR: {{ index .Values.global.connectivity.network.pods.cidrBlocks 0 | quote }}
       kubernetes:
         API:
-          clusterIPRange: {{ index .Values.connectivity.network.services.cidrBlocks 0 | quote }}
+          clusterIPRange: {{ index .Values.global.connectivity.network.services.cidrBlocks 0 | quote }}
         DNS:
           IP: {{ include "clusterDNS" $ | quote }}
     global:

--- a/helm/cluster-vsphere/templates/ipam/_ipam.tpl
+++ b/helm/cluster-vsphere/templates/ipam/_ipam.tpl
@@ -1,13 +1,13 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{- define "isIpamControlPlaneIPEnabled" -}}
-    {{- if and (and (not .Values.connectivity.network.controlPlaneEndpoint.host) (.Values.connectivity.network.controlPlaneEndpoint.ipPoolName)) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1alpha1/IPAddressClaim") }}
+    {{- if and (and (not .Values.global.connectivity.network.controlPlaneEndpoint.host) (.Values.global.connectivity.network.controlPlaneEndpoint.ipPoolName)) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1alpha1/IPAddressClaim") }}
         {{- printf "true" -}}
     {{- end }}
 {{- end }}
 
 {{- define "isIpamSvcLoadBalancerEnabled" -}}
-    {{- if and (.Values.connectivity.network.loadBalancers.ipPoolName) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1alpha1/IPAddressClaim") }}
+    {{- if and (.Values.global.connectivity.network.loadBalancers.ipPoolName) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1alpha1/IPAddressClaim") }}
         {{- printf "true" -}}
     {{- end }}
 {{- end }}

--- a/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
+++ b/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
@@ -129,8 +129,8 @@ spec:
               echo "Got the IP: ${new_ip}"
               new_ip="${new_ip}/32"
               # patch the cloud-provider-vsphere-helmrelease
-              {{- if .Values.connectivity.network.loadBalancers.cidrBlocks }}
-              new_ip="${new_ip},{{ join "," .Values.connectivity.network.loadBalancers.cidrBlocks }}"
+              {{- if .Values.global.connectivity.network.loadBalancers.cidrBlocks }}
+              new_ip="${new_ip},{{ join "," .Values.global.connectivity.network.loadBalancers.cidrBlocks }}"
               {{- end }}
               kubectl patch helmrelease -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }}-cloud-provider-vsphere --type=merge -p '{"spec":{"suspend":false,"values":{"kube-vip-cloud-provider": {"cidrGlobal": "'${new_ip}'"}}}}'
 {{- end }}

--- a/helm/cluster-vsphere/templates/ipam/ipAddressClaim.yaml
+++ b/helm/cluster-vsphere/templates/ipam/ipAddressClaim.yaml
@@ -9,5 +9,5 @@ spec:
   poolRef:
     apiGroup: ipam.cluster.x-k8s.io
     kind: GlobalInClusterIPPool
-    name: {{ .Values.connectivity.network.controlPlaneEndpoint.ipPoolName }}
+    name: {{ .Values.global.connectivity.network.controlPlaneEndpoint.ipPoolName }}
 {{- end }}

--- a/helm/cluster-vsphere/templates/ipam/ipAddressClaimLB.yaml
+++ b/helm/cluster-vsphere/templates/ipam/ipAddressClaimLB.yaml
@@ -9,5 +9,5 @@ spec:
   poolRef:
     apiGroup: ipam.cluster.x-k8s.io
     kind: GlobalInClusterIPPool
-    name: {{ .Values.connectivity.network.loadBalancers.ipPoolName }}
+    name: {{ .Values.global.connectivity.network.loadBalancers.ipPoolName }}
 {{- end }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -14,7 +14,7 @@ spec:
         - {{ .Values.global.connectivity.network.controlPlaneEndpoint.host }}
         - localhost
         - 127.0.0.1
-        - "api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
+        - "api.{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}"
         {{- with .Values.apiServer.certSANs }}
         {{- range . }}
         - {{ . }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -11,7 +11,7 @@ spec:
     clusterConfiguration:
       apiServer:
         certSANs:
-        - {{ .Values.connectivity.network.controlPlaneEndpoint.host }}
+        - {{ .Values.global.connectivity.network.controlPlaneEndpoint.host }}
         - localhost
         - 127.0.0.1
         - "api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
@@ -86,7 +86,7 @@ spec:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
           bind-address: "0.0.0.0"
       networking:
-        serviceSubnet: {{ join "," .Values.connectivity.network.services.cidrBlocks }}
+        serviceSubnet: {{ join "," .Values.global.connectivity.network.services.cidrBlocks }}
     {{- include "sshUsers" . | nindent 4 }}
     {{- include "ignitionSpec" . | nindent 4 }}
     initConfiguration:
@@ -117,7 +117,7 @@ spec:
       {{- include "sshFiles" . | nindent 6}}
       {{- include "teleportFiles" . | nindent 6 }}
       {{- include "auditLogFiles" . | nindent 6 }}
-      {{- if $.Values.proxy.enabled }}
+      {{- if $.Values.global.connectivity.proxy.enabled }}
       {{- include "containerdProxyConfig" . | nindent 6}}
       {{- include "teleportProxyConfig" . | nindent 6 }}
       {{- end }}
@@ -140,7 +140,7 @@ spec:
       {{- include "sshPreKubeadmCommands" . | nindent 6 }}
       - bash /etc/kubernetes/patches/kube-apiserver-patch.sh {{ .Values.controlPlane.resourceRatio }}
       - /bin/test ! -d /var/lib/kubelet && (/bin/mkdir -p /var/lib/kubelet && /bin/chmod 0750 /var/lib/kubelet)
-      {{- if $.Values.proxy.enabled }}
+      {{- if $.Values.global.connectivity.proxy.enabled }}
       - systemctl daemon-reload
       - systemctl restart containerd
       {{- if $.Values.internal.teleport.enabled }}

--- a/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
+++ b/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
@@ -27,7 +27,7 @@ stringData:
         - name: vip_leaderelection
           value: "true"
         - name: vip_address
-          value: {{ .Values.connectivity.network.controlPlaneEndpoint.host }}
+          value: {{ .Values.global.connectivity.network.controlPlaneEndpoint.host }}
         - name: vip_interface
           value: ens192
         - name: vip_leaseduration

--- a/helm/cluster-vsphere/templates/vspherecluster.yaml
+++ b/helm/cluster-vsphere/templates/vspherecluster.yaml
@@ -8,8 +8,8 @@ metadata:
     {{- include "preventDeletionLabel" $ | nindent 4 }}
 spec:
   controlPlaneEndpoint:
-    host: '{{ ((.Values.connectivity.network).controlPlaneEndpoint).host }}'
-    port: {{ ((.Values.connectivity.network).controlPlaneEndpoint).port | default 6443 }}
+    host: '{{ ((.Values.global.connectivity.network).controlPlaneEndpoint).host }}'
+    port: {{ ((.Values.global.connectivity.network).controlPlaneEndpoint).port | default 6443 }}
 
   identityRef:
     kind: Secret

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -43,6 +43,7 @@
 					"title": "Connectivity",
 					"description": "Configurations related to cluster connectivity such as container registries.",
 					"required": [
+						"baseDomain",
 						"network"
 					],
 					"additionalProperties": false,

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -38,6 +38,231 @@
 				"metadata"
 			],
 			"properties": {
+				"connectivity": {
+					"type": "object",
+					"title": "Connectivity",
+					"description": "Configurations related to cluster connectivity such as container registries.",
+					"required": [
+						"network"
+					],
+					"additionalProperties": false,
+					"properties": {
+						"baseDomain": {
+							"type": "string",
+							"title": "Base DNS domain",
+							"default": "k8s.test"
+						},
+						"containerRegistries": {
+							"type": "object",
+							"title": "Container registries",
+							"description": "Endpoints and credentials configuration for container registries.",
+							"additionalProperties": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"required": [
+										"endpoint"
+									],
+									"additionalProperties": false,
+									"properties": {
+										"credentials": {
+											"type": "object",
+											"title": "Credentials",
+											"description": "Credentials for the endpoint.",
+											"additionalProperties": false,
+											"properties": {
+												"auth": {
+													"type": "string",
+													"title": "Auth",
+													"description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
+												},
+												"identitytoken": {
+													"type": "string",
+													"title": "Identity token",
+													"description": "Used to authenticate the user and obtain an access token for the registry."
+												},
+												"password": {
+													"type": "string",
+													"title": "Password",
+													"description": "Used to authenticate for the registry with username/password."
+												},
+												"username": {
+													"type": "string",
+													"title": "Username",
+													"description": "Used to authenticate for the registry with username/password."
+												}
+											}
+										},
+										"endpoint": {
+											"type": "string",
+											"title": "Endpoint",
+											"description": "Endpoint for the container registry."
+										}
+									}
+								}
+							},
+							"default": {}
+						},
+						"network": {
+							"properties": {
+								"controlPlaneEndpoint": {
+									"description": "Kubernetes API configuration.",
+									"properties": {
+										"host": {
+											"title": "Host",
+											"description": "IP for access to the Kubernetes API. Manually select an IP for kube API. Empty string for auto selection from the ipPoolName pool.",
+											"type": "string"
+										},
+										"port": {
+											"title": "Port number",
+											"description": "Port for access to the Kubernetes API.",
+											"type": "integer"
+										},
+										"ipPoolName": {
+											"title": "Ip Pool Name",
+											"description": "Ip for control plane will be drawn from this GlobalInClusterIPPool resource.",
+											"type": "string",
+											"pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+											"default": "wc-cp-ips"
+										}
+									},
+									"title": "Endpoint",
+									"type": "object"
+								},
+								"pods": {
+									"properties": {
+										"cidrBlocks": {
+											"$ref": "#/$defs/cidrBlocks",
+											"default": "10.244.0.0/16",
+											"title": "Pod subnets"
+										}
+									},
+									"required": [
+										"cidrBlocks"
+									],
+									"title": "Pods",
+									"type": "object"
+								},
+								"services": {
+									"properties": {
+										"cidrBlocks": {
+											"$ref": "#/$defs/cidrBlocks",
+											"default": "172.31.0.0/16",
+											"title": "Service subnets"
+										}
+									},
+									"required": [
+										"cidrBlocks"
+									],
+									"title": "Services",
+									"type": "object"
+								},
+								"loadBalancers": {
+									"anyOf": [
+										{
+											"properties": {
+												"cidrBlocks": {
+													"$ref": "#/$defs/cidrBlocks",
+													"title": "Load Balancer subnets"
+												}
+											},
+											"required": ["cidrBlocks"]
+										},
+										{
+											"properties": {
+												"ipPoolName": {
+													"title": "Ip Pool Name",
+													"description": "Ip for Service LB running in WC will be drawn from this GlobalInClusterIPPool resource.",
+													"type": "string",
+													"pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+												}
+											},
+											"required": ["ipPoolName"]
+										}
+									],
+									"title": "Load balancers",
+									"type": "object"
+								}
+							},
+							"required": [
+								"pods",
+								"services",
+								"loadBalancers"
+							],
+							"title": "Network",
+							"type": "object"
+						},
+						"proxy": {
+							"type": "object",
+							"title": "Proxy",
+							"description": "Whether/how outgoing traffic is routed through proxy servers.",
+							"additionalProperties": false,
+							"properties": {
+								"enabled": {
+									"type": "boolean",
+									"title": "Enable"
+								},
+								"secretName": {
+									"type": "string",
+									"title": "Secret name",
+									"description": "Name of a secret resource used by containerd to obtain the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables. If empty the value will be defaulted to <clusterName>-cluster-values.",
+									"pattern": "^[a-z0-9-]{0,63}$"
+								}
+							}
+						},
+						"shell": {
+							"type": "object",
+							"title": "Shell access",
+							"additionalProperties": false,
+							"properties": {
+								"osUsers": {
+									"type": "array",
+									"title": "OS Users",
+									"description": "Configuration for OS users in cluster nodes.",
+									"items": {
+										"type": "object",
+										"title": "User",
+										"required": [
+											"name"
+										],
+										"additionalProperties": false,
+										"properties": {
+											"name": {
+												"type": "string",
+												"title": "Name",
+												"description": "Username of the user.",
+												"minLength": 2,
+												"pattern": "^[a-z][-a-z0-9]+$"
+											},
+											"sudo": {
+												"type": "string",
+												"title": "Sudoers configuration",
+												"description": "Permissions string to add to /etc/sudoers for this user."
+											}
+										}
+									},
+									"default": [
+										{
+											"name": "giantswarm",
+											"sudo": "ALL=(ALL) NOPASSWD:ALL"
+										}
+									]
+								},
+								"sshTrustedUserCAKeys": {
+									"type": "array",
+									"title": "Trusted SSH cert issuers",
+									"description": "CA certificates of issuers that are trusted to sign SSH user certificates.",
+									"items": {
+										"type": "string"
+									},
+									"default": [
+										"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
+									]
+								}
+							}
+						}
+					}
+				},		
 				"metadata": {
 					"type": "object",
 					"title": "Metadata",
@@ -100,7 +325,6 @@
 				}
 			}
 		},
-
 		"apiServer": {
 			"properties": {
 				"certSANs": {
@@ -174,155 +398,6 @@
 				}
 			},
 			"title": "Control plane",
-			"type": "object"
-		},
-		"connectivity": {
-			"properties": {
-				"network": {
-					"properties": {
-						"containerRegistries": {
-							"type": "object",
-							"title": "Container registries",
-							"description": "Endpoints and credentials configuration for container registries.",
-							"additionalProperties": {
-								"type": "array",
-								"items": {
-									"type": "object",
-									"required": [
-										"endpoint"
-									],
-									"additionalProperties": false,
-									"properties": {
-										"credentials": {
-											"type": "object",
-											"title": "Credentials",
-											"description": "Credentials for the endpoint.",
-											"additionalProperties": false,
-											"properties": {
-												"auth": {
-													"type": "string",
-													"title": "Auth",
-													"description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
-												},
-												"identitytoken": {
-													"type": "string",
-													"title": "Identity token",
-													"description": "Used to authenticate the user and obtain an access token for the registry."
-												},
-												"password": {
-													"type": "string",
-													"title": "Password",
-													"description": "Used to authenticate for the registry with username/password."
-												},
-												"username": {
-													"type": "string",
-													"title": "Username",
-													"description": "Used to authenticate for the registry with username/password."
-												}
-											}
-										},
-										"endpoint": {
-											"type": "string",
-											"title": "Endpoint",
-											"description": "Endpoint for the container registry."
-										}
-									}
-								}
-							},
-							"default": {}
-						},
-						"controlPlaneEndpoint": {
-							"description": "Kubernetes API configuration.",
-							"properties": {
-								"host": {
-									"title": "Host",
-									"description": "IP for access to the Kubernetes API. Manually select an IP for kube API. Empty string for auto selection from the ipPoolName pool.",
-									"type": "string"
-								},
-								"port": {
-									"title": "Port number",
-									"description": "Port for access to the Kubernetes API.",
-									"type": "integer"
-								},
-								"ipPoolName": {
-									"title": "Ip Pool Name",
-									"description": "Ip for control plane will be drawn from this GlobalInClusterIPPool resource.",
-									"type": "string",
-									"pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
-									"default": "wc-cp-ips"
-								}
-							},
-							"title": "Endpoint",
-							"type": "object"
-						},
-						"pods": {
-							"properties": {
-								"cidrBlocks": {
-									"$ref": "#/$defs/cidrBlocks",
-									"default": "10.244.0.0/16",
-									"title": "Pod subnets"
-								}
-							},
-							"required": [
-								"cidrBlocks"
-							],
-							"title": "Pods",
-							"type": "object"
-						},
-						"services": {
-							"properties": {
-								"cidrBlocks": {
-									"$ref": "#/$defs/cidrBlocks",
-									"default": "172.31.0.0/16",
-									"title": "Service subnets"
-								}
-							},
-							"required": [
-								"cidrBlocks"
-							],
-							"title": "Services",
-							"type": "object"
-						},
-						"loadBalancers": {
-							"anyOf": [
-								{
-									"properties": {
-										"cidrBlocks": {
-											"$ref": "#/$defs/cidrBlocks",
-											"title": "Load Balancer subnets"
-										}
-									},
-									"required": ["cidrBlocks"]
-								},
-								{
-									"properties": {
-										"ipPoolName": {
-											"title": "Ip Pool Name",
-											"description": "Ip for Service LB running in WC will be drawn from this GlobalInClusterIPPool resource.",
-											"type": "string",
-											"pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
-										}
-									},
-									"required": ["ipPoolName"]
-								}
-							],
-							"title": "Load balancers",
-							"type": "object"
-						}
-					},
-					"required": [
-						"pods",
-						"services",
-						"loadBalancers"
-					],
-					"title": "Network",
-					"type": "object"
-				}
-			},
-			"required": [
-				"network"
-			],
-			"title": "Connectivity",
 			"type": "object"
 		},
 		"internal": {

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -49,8 +49,7 @@
 					"properties": {
 						"baseDomain": {
 							"type": "string",
-							"title": "Base DNS domain",
-							"default": "k8s.test"
+							"title": "Base DNS domain"
 						},
 						"containerRegistries": {
 							"type": "object",

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -104,8 +104,6 @@ oidc:
   groupsClaim: ""
   usernamePrefix: ""
 
-
-
 vcenter:
   datacenter: ""
   username: ""

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -44,6 +44,9 @@ global:
       services:
         cidrBlocks:
         - "172.31.0.0/16"
+    proxy:
+      secretName: ""
+      enabled: false
     shell:
       osUsers:
         - name: "giantswarm"
@@ -102,9 +105,7 @@ oidc:
   groupsClaim: ""
   usernamePrefix: ""
 
-proxy:
-  secretName: ""
-  enabled: false
+
 
 vcenter:
   datacenter: ""

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -44,9 +44,7 @@ global:
       services:
         cidrBlocks:
         - "172.31.0.0/16"
-    proxy:
-      secretName: ""
-      enabled: false
+    proxy: {}
     shell:
       osUsers:
         - name: "giantswarm"

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -29,6 +29,7 @@ controlPlane:
 
 global:
   connectivity:
+    containerRegistries: {}
     network:
       controlPlaneEndpoint:
         host: ""
@@ -43,7 +44,6 @@ global:
       services:
         cidrBlocks:
         - "172.31.0.0/16"
-    containerRegistries: {}
     shell:
       osUsers:
         - name: "giantswarm"

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -29,7 +29,6 @@ controlPlane:
 
 global:
   connectivity:
-    baseDomain: k8s.test
     containerRegistries: {}
     network:
       controlPlaneEndpoint:

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -44,6 +44,12 @@ global:
         cidrBlocks:
         - "172.31.0.0/16"
     containerRegistries: {}
+    shell:
+      osUsers:
+        - name: "giantswarm"
+          sudo: "ALL=(ALL) NOPASSWD:ALL"
+      sshTrustedUserCAKeys:
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
   podSecurityStandards:
     enforced: true
   metadata:
@@ -96,16 +102,9 @@ oidc:
   groupsClaim: ""
   usernamePrefix: ""
 
-osUsers:
-- name: "giantswarm"
-  sudo: "ALL=(ALL) NOPASSWD:ALL"
-
 proxy:
   secretName: ""
   enabled: false
-
-sshTrustedUserCAKeys:
-  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
 
 vcenter:
   datacenter: ""

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -7,23 +7,6 @@ cluster:
   kubernetesVersion: "v1.25.16"
   enableEncryptionProvider: true
 
-connectivity:
-  network:
-    controlPlaneEndpoint:
-      host: ""
-      port: 6443
-      ipPoolName: "wc-cp-ips"
-    loadBalancers:
-      cidrBlocks: []
-      ipPoolName: "svc-lb-ips"
-    pods:
-      cidrBlocks:
-      - "10.244.0.0/16"
-    services:
-      cidrBlocks:
-      - "172.31.0.0/16"
-  containerRegistries: {}
-
 controllerManager:
   featureGates: ""
 
@@ -45,6 +28,22 @@ controlPlane:
   resourceRatio: 8
 
 global:
+  connectivity:
+    network:
+      controlPlaneEndpoint:
+        host: ""
+        port: 6443
+        ipPoolName: "wc-cp-ips"
+      loadBalancers:
+        cidrBlocks: []
+        ipPoolName: "svc-lb-ips"
+      pods:
+        cidrBlocks:
+        - "10.244.0.0/16"
+      services:
+        cidrBlocks:
+        - "172.31.0.0/16"
+    containerRegistries: {}
   podSecurityStandards:
     enforced: true
   metadata:

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -29,6 +29,7 @@ controlPlane:
 
 global:
   connectivity:
+    baseDomain: k8s.test
     containerRegistries: {}
     network:
       controlPlaneEndpoint:


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/3372


Notes: 

- it's not possible to test this using the e2e CI tests because the [test cluster values](https://github.com/giantswarm/cluster-standup-teardown/blob/main/pkg/clusterbuilder/providers/capv/values/cluster_values.yaml) have not been updated yet (and cannot be updated until the chart refactoring is complete and released). Running the CI tests locally with manually updated values passes though:

```
Ran 18 of 27 Specs in 1850.070 seconds
SUCCESS! -- 18 Passed | 0 Failed | 0 Pending | 9 Skipped
PASS

Ginkgo ran 1 suite in 30m59.16497128s
Test Suite Passed
```

