### PR TITLE
refactor: move controlplane values under global key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
     with(select(.sshTrustedUserCAKeys != null);     .global.connectivity.shell.sshTrustedUserCAKeys = .sshTrustedUserCAKeys) |
     with(select(.proxy != null);                    .global.connectivity.proxy = .proxy) |
     with(select(.baseDomain != null);               .global.connectivity.baseDomain = .baseDomain) |
+    with(select(.controlPlane != null);             .global.controlPlane = .controlPlane) |
+    with(select(.oidc != null);                     .global.controlPlane.oidc = .oidc) |
 
     del(.metadata) |
     del(.clusterDescription) |
@@ -36,7 +38,9 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
     del(.osUsers) |
     del(.sshTrustedUserCAKeys) |
     del(.proxy) |
-    del(.baseDomain)' values.yaml
+    del(.baseDomain) |
+    del(.controlPlane) |
+    del(.oidc)' values.yaml
 ```
 
 </details>
@@ -53,6 +57,8 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
 - Move Helm values property `.Values.osUsers` to `.Values.global.connectivity.shell.osUsers`.
 - Move Helm values property `.Values.sshTrustedUserCAKeys` to `.Values.global.connectivity.shell.sshTrustedUserCAKeys`.
 - Move Helm values property `.Values.baseDomain` to `.Values.global.connectivity.baseDomain`.
+- Move Helm values property `.Values.controlPlane` to `.Values.global.controlPlane`.
+- Move Helm values property `.Values.oidc` to `.Values.global.controlPlane.oidc`.
 
 ## [0.50.0] - 2024-04-23
 

--- a/helm/cluster-vsphere/ci/ci-values.yaml
+++ b/helm/cluster-vsphere/ci/ci-values.yaml
@@ -12,19 +12,6 @@ vcenter:
   thumbprint: "F7:CF:F9:E5:99:39:FF:C1:D7:14:F1:3F:8A:42:21:95:3B:A1:6E:16"
   region: "k8s-region"
   zone: "k8s-zone"
-controlPlane:
-  replicas: 1
-  machineTemplate:
-    template: "ubuntu-2004-kube-v1.24.11"
-    cloneMode: "linkedClone"
-    diskGiB: 25
-    numCPUs: 2
-    memoryMiB: 8192
-    resourcePool: "grasshopper"
-    network:
-      devices:
-        - networkName: 'grasshopper-capv'
-          dhcp4: true
 nodeClasses:
   default:
     template: "ubuntu-2004-kube-v1.24.11"
@@ -54,3 +41,16 @@ global:
         cidrBlocks:
           - "10.10.222.224/30"
     baseDomain: k8s.test
+  controlPlane:
+    replicas: 1
+    machineTemplate:
+      template: "ubuntu-2004-kube-v1.24.11"
+      cloneMode: "linkedClone"
+      diskGiB: 25
+      numCPUs: 2
+      memoryMiB: 8192
+      resourcePool: "grasshopper"
+      network:
+        devices:
+          - networkName: 'grasshopper-capv'
+            dhcp4: true

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -163,7 +163,7 @@ postKubeadmCommands:
 
 {{- define "mtRevisionByControlPlane" -}}
 {{- $outerScope := . }}
-{{- include "mtRevision" (merge (dict "currentClass" .Values.controlPlane.machineTemplate) $outerScope.Values) }}
+{{- include "mtRevision" (merge (dict "currentClass" .Values.global.controlPlane.machineTemplate) $outerScope.Values) }}
 {{- end -}}
 
 {{/*

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -33,7 +33,7 @@ spec:
           {{- end }}
           feature-gates: {{ .Values.apiServer.featureGates | quote }}
           kubelet-preferred-address-types: "InternalIP"
-          {{- if .Values.global.controlPlane.oidc }}
+          {{- if .Values.global.controlPlane.oidc.issuerUrl }}
           {{- with .Values.global.controlPlane.oidc }}
           oidc-issuer-url: {{ .issuerUrl }}
           oidc-client-id: {{ .clientId }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -33,8 +33,8 @@ spec:
           {{- end }}
           feature-gates: {{ .Values.apiServer.featureGates | quote }}
           kubelet-preferred-address-types: "InternalIP"
-          {{- if .Values.oidc.issuerUrl }}
-          {{- with .Values.oidc }}
+          {{- if .Values.global.controlPlane.oidc.issuerUrl }}
+          {{- with .Values.global.controlPlane.oidc }}
           oidc-issuer-url: {{ .issuerUrl }}
           oidc-client-id: {{ .clientId }}
           oidc-username-claim: {{ .usernameClaim }}
@@ -80,7 +80,7 @@ spec:
         local:
           extraArgs:
             listen-metrics-urls: "http://0.0.0.0:2381"
-      imageRepository: {{ .Values.controlPlane.image.repository }}
+      imageRepository: {{ .Values.global.controlPlane.image.repository }}
       scheduler:
         extraArgs:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
@@ -138,7 +138,7 @@ spec:
       {{- end }}
     preKubeadmCommands:
       {{- include "sshPreKubeadmCommands" . | nindent 6 }}
-      - bash /etc/kubernetes/patches/kube-apiserver-patch.sh {{ .Values.controlPlane.resourceRatio }}
+      - bash /etc/kubernetes/patches/kube-apiserver-patch.sh {{ .Values.global.controlPlane.resourceRatio }}
       - /bin/test ! -d /var/lib/kubelet && (/bin/mkdir -p /var/lib/kubelet && /bin/chmod 0750 /var/lib/kubelet)
       {{- if $.Values.global.connectivity.proxy.enabled }}
       - systemctl daemon-reload
@@ -153,5 +153,5 @@ spec:
       kind: VSphereMachineTemplate
       name: {{ include "resource.default.name" . }}-control-plane-{{ include "mtRevisionByControlPlane" $ }}
       namespace: {{ .Release.Namespace }}
-  replicas: {{ .Values.controlPlane.replicas }}
+  replicas: {{ .Values.global.controlPlane.replicas }}
   version: {{ .Values.cluster.kubernetesVersion }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -33,7 +33,7 @@ spec:
           {{- end }}
           feature-gates: {{ .Values.apiServer.featureGates | quote }}
           kubelet-preferred-address-types: "InternalIP"
-          {{- if .Values.global.controlPlane.oidc.issuerUrl }}
+          {{- if .Values.global.controlPlane.oidc }}
           {{- with .Values.global.controlPlane.oidc }}
           oidc-issuer-url: {{ .issuerUrl }}
           oidc-client-id: {{ .clientId }}

--- a/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
+++ b/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
@@ -1,4 +1,4 @@
-{{- range $name, $value := (merge .Values.nodeClasses (dict "control-plane" .Values.controlPlane.machineTemplate)) }}
+{{- range $name, $value := (merge .Values.nodeClasses (dict "control-plane" .Values.global.controlPlane.machineTemplate)) }}
 {{- $c := (merge (dict "currentClass"  $value) $.Values) }}
 ---
 apiVersion: {{ include "infrastructureApiVersion" . }}

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -264,6 +264,9 @@
 					}
 				},
 				"controlPlane": {
+					"type": "object",
+					"title": "Control plane",
+					"additionalProperties": false,
 					"properties": {
 						"dns": {
 							"type": "object",
@@ -313,7 +316,7 @@
 						},
 						"machineTemplate": {
 							"type": "object",
-							"title": "Machine template for control plane nodes.",
+							"title": "Template to define control plane nodes",
 							"additionalProperties": false,
 							"required": [
 								"network"
@@ -326,16 +329,18 @@
 									"default": "linkedClone"
 								},
 								"diskGiB": {
-									"type": "number",
+									"type": "integer",
 									"title": "Disk size",
 									"description": "Control plane node root volume size, in GB.",
-									"default": "50"
+									"default": 50,
+									"minimum": 50
 								},
 								"memoryMiB": {
-									"type": "number",
+									"type": "integer",
 									"title": "Memory size",
 									"description": "Control plane memory size, in MB.",
-									"default": "8192"
+									"default": 8192,
+									"minimum": 8192
 								},
 								"network": {
 									"type": "object",
@@ -372,15 +377,16 @@
 									}
 								},
 								"numCPUs": {
-									"type": "number",
+									"type": "integer",
 									"title": "Number of CPUs",
 									"description": "Control plane CPU count.",
-									"default": "4"
+									"default": 4,
+									"minimum": 4
 								},
 								"resourcePool": {
 									"type": "string",
 									"title": "Resource pool name",
-									"description": "vSphere resource pool name."
+									"description": "Name of the resource pool to use."
 								},
 								"template": {
 									"type": "string",
@@ -392,13 +398,15 @@
 						},
 						"replicas": {
 							"title": "Number of nodes",
-							"type": "integer"
+							"type": "integer",
+							"minimum": 1
 						},
 						"resourceRatio": {
+							"type": "integer",
 							"title": "Resource ratio",
 							"description": "Ratio between node resources and apiserver resource requests.",
 							"default": 8,
-							"type": "integer"
+							"minimum": 8
 						},
 						"oidc": {
 							"type": "object",
@@ -448,9 +456,7 @@
 								}
 							}
 						}
-					},
-					"title": "Control plane",
-					"type": "object"
+					}
 				},
 				"metadata": {
 					"type": "object",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -411,12 +411,6 @@
 						"oidc": {
 							"type": "object",
 							"title": "OIDC authentication",
-							"required": [
-								"clientId",
-								"groupsClaim",
-								"issuerUrl",
-								"usernameClaim"
-							],
 							"additionalProperties": false,
 							"properties": {
 								"caFile": {

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -333,7 +333,7 @@
 									"title": "Disk size",
 									"description": "Control plane node root volume size, in GB.",
 									"default": 50,
-									"minimum": 50
+									"minimum": 25
 								},
 								"memoryMiB": {
 									"type": "integer",
@@ -381,7 +381,7 @@
 									"title": "Number of CPUs",
 									"description": "Control plane CPU count.",
 									"default": 4,
-									"minimum": 4
+									"minimum": 2
 								},
 								"resourcePool": {
 									"type": "string",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -262,7 +262,196 @@
 							}
 						}
 					}
-				},		
+				},
+				"controlPlane": {
+					"properties": {
+						"dns": {
+							"type": "object",
+							"title": "DNS container image",
+							"additionalProperties": false,
+							"properties": {
+								"imageRepository": {
+									"type": "string",
+									"title": "Repository",
+									"default": "gsoci.azurecr.io/giantswarm"
+								},
+								"imageTag": {
+									"type": "string",
+									"title": "Tag",
+									"default": "1.9.4-giantswarm"
+								}
+							}
+						},
+						"etcd": {
+							"type": "object",
+							"title": "Etcd container image",
+							"additionalProperties": false,
+							"properties": {
+								"imageRepository": {
+									"type": "string",
+									"title": "Repository",
+									"default": "gsoci.azurecr.io/giantswarm"
+								},
+								"imageTag": {
+									"type": "string",
+									"title": "Tag",
+									"default": "3.5.4-0-k8s"
+								}
+							}
+						},
+						"image": {
+							"type": "object",
+							"title": "Node container image",
+							"additionalProperties": false,
+							"properties": {
+								"repository": {
+									"type": "string",
+									"title": "Repository",
+									"default": "gsoci.azurecr.io/giantswarm"
+								}
+							}
+						},
+						"machineTemplate": {
+							"type": "object",
+							"title": "Machine template for control plane nodes.",
+							"additionalProperties": false,
+							"required": [
+								"network"
+							],
+							"properties": {
+								"cloneMode": {
+									"type": "string",
+									"title": "Template clone mode",
+									"description": "VM template cloning method.",
+									"default": "linkedClone"
+								},
+								"diskGiB": {
+									"type": "number",
+									"title": "Disk size",
+									"description": "Control plane node root volume size, in GB.",
+									"default": "50"
+								},
+								"memoryMiB": {
+									"type": "number",
+									"title": "Memory size",
+									"description": "Control plane memory size, in MB.",
+									"default": "8192"
+								},
+								"network": {
+									"type": "object",
+									"title": "Network configuration",
+									"description": "Control plane node network configuration.",
+									"additionalProperties": false,
+									"properties": {
+										"devices": {
+											"type": "array",
+											"title": "Network devices",
+											"description": "Control plane node network devices.",
+											"additionalProperties": false,
+											"items": {
+												"type": "object",
+												"title": "Devices",
+												"required": [
+													"networkName"
+												],
+												"additionalProperties": false,
+												"properties": {
+													"dhcp4": {
+														"type": "boolean",
+														"title": "IPv4 DHCP",
+														"description": "Is DHCP enabled on this segment."
+													},
+													"networkName": {
+														"type": "string",
+														"title": "Segment name",
+														"description": "Segment name to attach nodes to. Must already exist."
+													}
+												}
+											}
+										}
+									}
+								},
+								"numCPUs": {
+									"type": "number",
+									"title": "Number of CPUs",
+									"description": "Control plane CPU count.",
+									"default": "4"
+								},
+								"resourcePool": {
+									"type": "string",
+									"title": "Resource pool name",
+									"description": "vSphere resource pool name."
+								},
+								"template": {
+									"type": "string",
+									"title": "VM template",
+									"description": "Full name of the VM template.",
+									"default": "flatcar-stable-3602.2.1-kube-v1.25.16-gs"
+								}
+							}
+						},
+						"replicas": {
+							"title": "Number of nodes",
+							"type": "integer"
+						},
+						"resourceRatio": {
+							"title": "Resource ratio",
+							"description": "Ratio between node resources and apiserver resource requests.",
+							"default": 8,
+							"type": "integer"
+						},
+						"oidc": {
+							"type": "object",
+							"title": "OIDC authentication",
+							"required": [
+								"clientId",
+								"groupsClaim",
+								"issuerUrl",
+								"usernameClaim"
+							],
+							"additionalProperties": false,
+							"properties": {
+								"caFile": {
+									"type": "string",
+									"title": "Certificate authority file",
+									"description": "Path to identity provider's CA certificate in PEM format."
+								},
+								"clientId": {
+									"type": "string",
+									"title": "Client ID",
+									"description": "OIDC client identifier to identify with."
+								},
+								"groupsClaim": {
+									"type": "string",
+									"title": "Groups claim",
+									"description": "Name of the identity token claim bearing the user's group memberships."
+								},
+								"groupsPrefix": {
+									"type": "string",
+									"title": "Groups prefix",
+									"description": "Prefix prepended to groups values to prevent clashes with existing names."
+								},
+								"issuerUrl": {
+									"type": "string",
+									"title": "Issuer URL",
+									"description": "URL of the provider which allows the API server to discover public signing keys, not including any path. Discovery URL without the '/.well-known/openid-configuration' part."
+								},
+								"usernameClaim": {
+									"type": "string",
+									"title": "Username claim",
+									"description": "Name of the identity token claim bearing the unique user identifier."
+								},
+								"usernamePrefix": {
+									"type": "string",
+									"title": "Username prefix",
+									"description": "Prefix prepended to username values to prevent clashes with existing names."
+								}
+							}
+						}
+					},
+					"title": "Control plane",
+					"type": "object"
+				},
 				"metadata": {
 					"type": "object",
 					"title": "Metadata",
@@ -370,34 +559,6 @@
 				"featureGates"
 			],
 			"title": "Kubernetes Controller Manager",
-			"type": "object"
-		},
-		"controlPlane": {
-			"properties": {
-				"image": {
-					"type": "object",
-					"title": "Node container image",
-					"additionalProperties": false,
-					"properties": {
-						"repository": {
-							"type": "string",
-							"title": "Repository",
-							"default": "gsoci.azurecr.io/giantswarm"
-						}
-					}
-				},
-				"replicas": {
-					"title": "Number of nodes",
-					"type": "integer"
-				},
-				"resourceRatio": {
-					"title": "Resource ratio",
-					"description": "Ratio between node resources and apiserver resource requests.",
-					"default": 8,
-					"type": "integer"
-				}
-			},
-			"title": "Control plane",
 			"type": "object"
 		},
 		"internal": {

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -45,11 +45,13 @@ global:
       repository: gsoci.azurecr.io/giantswarm
     machineTemplate:
       cloneMode: linkedClone
-      diskGiB: "50"
-      memoryMiB: "8192"
+      diskGiB: 50
+      memoryMiB: 8192
       network: {}
-      numCPUs: "4"
+      numCPUs: 4
       template: flatcar-stable-3602.2.1-kube-v1.25.16-gs
+    oidc: {}
+    resourceRatio: 8
   podSecurityStandards:
     enforced: true
   metadata:

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -10,23 +10,6 @@ cluster:
 controllerManager:
   featureGates: ""
 
-controlPlane:
-  replicas: 1
-  machineTemplate:
-    cloneMode: "linkedClone"
-    diskGiB: 50
-    numCPUs: 4
-    template: "flatcar-stable-3602.2.1-kube-v1.25.16-gs"
-    resourcePool: "*/Resources"
-    memoryMiB: 8192
-    network:
-      devices:
-      - dhcp4: true
-        networkName: ""
-  image:
-    repository: gsoci.azurecr.io/giantswarm
-  resourceRatio: 8
-
 global:
   connectivity:
     containerRegistries: {}
@@ -51,6 +34,22 @@ global:
           sudo: "ALL=(ALL) NOPASSWD:ALL"
       sshTrustedUserCAKeys:
         - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
+  controlPlane:
+    dns:
+      imageRepository: gsoci.azurecr.io/giantswarm
+      imageTag: 1.9.4-giantswarm
+    etcd:
+      imageRepository: gsoci.azurecr.io/giantswarm
+      imageTag: 3.5.4-0-k8s
+    image:
+      repository: gsoci.azurecr.io/giantswarm
+    machineTemplate:
+      cloneMode: linkedClone
+      diskGiB: "50"
+      memoryMiB: "8192"
+      network: {}
+      numCPUs: "4"
+      template: flatcar-stable-3602.2.1-kube-v1.25.16-gs
   podSecurityStandards:
     enforced: true
   metadata:
@@ -94,14 +93,6 @@ nodePools:
   worker:
     class: default
     replicas: 2
-
-oidc:
-  issuerUrl: ""
-  caFile: ""
-  clientId: ""
-  usernameClaim: ""
-  groupsClaim: ""
-  usernamePrefix: ""
 
 vcenter:
   datacenter: ""


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/3372


Notes: 

- it's not possible to test this using the e2e CI tests because the [test cluster values](https://github.com/giantswarm/cluster-standup-teardown/blob/main/pkg/clusterbuilder/providers/capv/values/cluster_values.yaml) have not been updated yet (and cannot be updated until the chart refactoring is complete and released). Running the CI tests locally with manually updated values passes though:

```
Ran 18 of 27 Specs in 2127.030 seconds
SUCCESS! -- 18 Passed | 0 Failed | 0 Pending | 9 Skipped
PASS

Ginkgo ran 1 suite in 35m34.747568803s
Test Suite Passed
```
