### PR TITLE
refactor: move nodepools under global key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
     with(select(.baseDomain != null);               .global.connectivity.baseDomain = .baseDomain) |
     with(select(.controlPlane != null);             .global.controlPlane = .controlPlane) |
     with(select(.oidc != null);                     .global.controlPlane.oidc = .oidc) |
+    with(select(.nodePools != null);                .global.nodePools = .nodePools) |
 
     del(.metadata) |
     del(.clusterDescription) |
@@ -40,7 +41,8 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
     del(.proxy) |
     del(.baseDomain) |
     del(.controlPlane) |
-    del(.oidc)' values.yaml
+    del(.oidc) |
+    del(.nodePools)' values.yaml
 ```
 
 </details>
@@ -59,6 +61,7 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
 - Move Helm values property `.Values.baseDomain` to `.Values.global.connectivity.baseDomain`.
 - Move Helm values property `.Values.controlPlane` to `.Values.global.controlPlane`.
 - Move Helm values property `.Values.oidc` to `.Values.global.controlPlane.oidc`.
+- Move Helm values property `.Values.nodePools` to `.Values.global.nodePools`.
 
 ## [0.50.0] - 2024-04-23
 

--- a/helm/cluster-vsphere/ci/ci-values.yaml
+++ b/helm/cluster-vsphere/ci/ci-values.yaml
@@ -24,10 +24,6 @@ nodeClasses:
       devices:
         - networkName: 'grasshopper-capv'
           dhcp4: true
-nodePools:
-  worker:
-    class: "default"
-    replicas: 2
 global:
   metadata:
     description: "test cluster"
@@ -54,3 +50,7 @@ global:
         devices:
           - networkName: 'grasshopper-capv'
             dhcp4: true
+  nodePools:
+    worker:
+      class: "default"
+      replicas: 2

--- a/helm/cluster-vsphere/templates/kubeadmconfigtemplate.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmconfigtemplate.yaml
@@ -1,4 +1,4 @@
-{{- range $name, $value := .Values.nodePools }}
+{{- range $name, $value := .Values.global.nodePools }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/helm/cluster-vsphere/templates/machinedeployment.yaml
+++ b/helm/cluster-vsphere/templates/machinedeployment.yaml
@@ -1,4 +1,4 @@
-{{- range $name, $value := .Values.nodePools }}
+{{- range $name, $value := .Values.global.nodePools }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -43,6 +43,7 @@
 					"title": "Connectivity",
 					"description": "Configurations related to cluster connectivity such as container registries.",
 					"required": [
+						"baseDomain",
 						"network"
 					],
 					"additionalProperties": false,

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -500,6 +500,53 @@
 						}
 					}
 				},
+				"nodePools": {
+					"type": "object",
+					"title": "Node pools",
+					"description": "Groups of worker nodes with identical configuration.",
+					"additionalProperties": false,
+					"patternProperties": {
+						"^[a-z0-9-]{3,10}$": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"class": {
+									"type": "string",
+									"title": "Node class",
+									"description": "A valid node class name.",
+									"pattern": "^[a-z0-9-]+$"
+								},
+								"replicas": {
+									"type": "integer",
+									"title": "Number of nodes",
+									"default": 1,
+									"minimum": 1
+								}
+							}
+						}
+					},
+					"properties": {
+						"worker": {
+							"type": "object",
+							"title": "Default nodePool",
+							"additionalProperties": false,
+							"properties": {
+								"class": {
+									"type": "string",
+									"title": "Node class",
+									"description": "A valid node class name.",
+									"default": "default"
+								},
+								"replicas": {
+									"type": "integer",
+									"title": "Number of nodes",
+									"default": 2,
+									"minimum": 1
+								}
+							}
+						}
+					}
+				},
 				"podSecurityStandards": {
 					"type": "object",
 					"title": "Pod Security Standards",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -43,7 +43,6 @@
 					"title": "Connectivity",
 					"description": "Configurations related to cluster connectivity such as container registries.",
 					"required": [
-						"baseDomain",
 						"network"
 					],
 					"additionalProperties": false,

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -12,6 +12,7 @@ controllerManager:
 
 global:
   connectivity:
+    baseDomain: k8s.test
     containerRegistries: {}
     network:
       controlPlaneEndpoint:

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -12,7 +12,6 @@ controllerManager:
 
 global:
   connectivity:
-    containerRegistries: {}
     network:
       controlPlaneEndpoint:
         host: ""

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -12,7 +12,6 @@ controllerManager:
 
 global:
   connectivity:
-    baseDomain: k8s.test
     containerRegistries: {}
     network:
       controlPlaneEndpoint:

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -91,10 +91,6 @@ nodeClasses:
       - networkName: ""
         dhcp4: true
 
-nodePools:
-  worker:
-    class: default
-    replicas: 2
 
 vcenter:
   datacenter: ""

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -12,6 +12,7 @@ controllerManager:
 
 global:
   connectivity:
+    containerRegistries: {}
     network:
       controlPlaneEndpoint:
         host: ""


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/3372


Notes: 

- it's not possible to test this using the e2e CI tests because the [test cluster values](https://github.com/giantswarm/cluster-standup-teardown/blob/main/pkg/clusterbuilder/providers/capv/values/cluster_values.yaml) have not been updated yet (and cannot be updated until the chart refactoring is complete and released). Running the CI tests locally with manually updated values passes though:

```
Ran 18 of 27 Specs in 1839.581 seconds
SUCCESS! -- 18 Passed | 0 Failed | 0 Pending | 9 Skipped
PASS

Ginkgo ran 1 suite in 30m48.547890827s
Test Suite Passed
```

