### PR TITLE
refactor: create providerSpecific key under global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
     with(select(.controlPlane != null);             .global.controlPlane = .controlPlane) |
     with(select(.oidc != null);                     .global.controlPlane.oidc = .oidc) |
     with(select(.nodePools != null);                .global.nodePools = .nodePools) |
+    with(select(.vcenter != null);                  .global.providerSpecific.vcenter = .vcenter) |
 
     del(.metadata) |
     del(.clusterDescription) |
@@ -42,7 +43,8 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
     del(.baseDomain) |
     del(.controlPlane) |
     del(.oidc) |
-    del(.nodePools)' values.yaml
+    del(.nodePools) |
+    del(.vcenter)' values.yaml
 ```
 
 </details>
@@ -62,6 +64,7 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
 - Move Helm values property `.Values.controlPlane` to `.Values.global.controlPlane`.
 - Move Helm values property `.Values.oidc` to `.Values.global.controlPlane.oidc`.
 - Move Helm values property `.Values.nodePools` to `.Values.global.nodePools`.
+- Move Helm values property `.Values.vcenter` to `.Values.global.providerSpecific.vcenter`.
 
 ## [0.50.0] - 2024-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
     with(select(.baseDomain != null);               .global.connectivity.baseDomain = .baseDomain) |
     with(select(.controlPlane != null);             .global.controlPlane = .controlPlane) |
     with(select(.oidc != null);                     .global.controlPlane.oidc = .oidc) |
+    with(select(.nodePools != null);                .global.nodePools = .nodePools) |
 
     del(.metadata) |
     del(.clusterDescription) |
@@ -40,7 +41,8 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
     del(.proxy) |
     del(.baseDomain) |
     del(.controlPlane) |
-    del(.oidc)' values.yaml
+    del(.oidc) |
+    del(.nodePools)' values.yaml
 ```
 
 </details>
@@ -59,6 +61,7 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
 - Move Helm values property `.Values.baseDomain` to `.Values.global.connectivity.baseDomain`.
 - Move Helm values property `.Values.controlPlane` to `.Values.global.controlPlane`.
 - Move Helm values property `.Values.oidc` to `.Values.global.controlPlane.oidc`.
+- Move Helm values property `.Values.nodePools` to `.Values.global.nodePools`.
 
 ## [0.50.0] - 2024-04-23
 

--- a/helm/cluster-vsphere/ci/ci-values.yaml
+++ b/helm/cluster-vsphere/ci/ci-values.yaml
@@ -2,16 +2,6 @@ cluster:
   name: test
   kubernetesVersion: "v1.24.11"
   enableEncryptionProvider: false
-vcenter:
-  server: "https://foo.example.com"
-  username: "vcenter-admin"
-  password: "vcenter-admin-password"
-  datacenter: "Datacenter"
-  datastore: "vsanDatastore"
-  # openssl s_client -connect https://foo.example.com < /dev/null 2>/dev/null | openssl x509 -fingerprint -noout -in /dev/stdin
-  thumbprint: "F7:CF:F9:E5:99:39:FF:C1:D7:14:F1:3F:8A:42:21:95:3B:A1:6E:16"
-  region: "k8s-region"
-  zone: "k8s-zone"
 nodeClasses:
   default:
     template: "ubuntu-2004-kube-v1.24.11"
@@ -54,3 +44,14 @@ global:
     worker:
       class: "default"
       replicas: 2
+  providerSpecific:
+    vcenter:
+      server: "https://foo.example.com"
+      username: "vcenter-admin"
+      password: "vcenter-admin-password"
+      datacenter: "Datacenter"
+      datastore: "vsanDatastore"
+      # openssl s_client -connect https://foo.example.com < /dev/null 2>/dev/null | openssl x509 -fingerprint -noout -in /dev/stdin
+      thumbprint: "F7:CF:F9:E5:99:39:FF:C1:D7:14:F1:3F:8A:42:21:95:3B:A1:6E:16"
+      region: "k8s-region"
+      zone: "k8s-zone"

--- a/helm/cluster-vsphere/ci/ci-values.yaml
+++ b/helm/cluster-vsphere/ci/ci-values.yaml
@@ -24,10 +24,6 @@ nodeClasses:
       devices:
         - networkName: 'grasshopper-capv'
           dhcp4: true
-nodePools:
-  worker:
-    class: "default"
-    replicas: 2
 global:
   metadata:
     description: "test cluster"
@@ -54,3 +50,7 @@ global:
         devices:
           - networkName: 'grasshopper-capv'
             dhcp4: true
+  nodePools:
+    worker:
+      class: "default"
+      replicas: 2

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -24,10 +24,10 @@ Here we are generating a hash suffix to trigger upgrade when only it is necessar
 using only the parameters used in vspheredmachinetemplate.yaml.
 */}}
 {{- define "mtSpec" -}}
-datacenter: {{ $.vcenter.datacenter }}
-datastore: {{ $.vcenter.datastore }}
-server: {{ $.vcenter.server }}
-thumbprint: {{ $.vcenter.thumbprint }}
+datacenter: {{ $.global.providerSpecific.vcenter.datacenter }}
+datastore: {{ $.global.providerSpecific.vcenter.datastore }}
+server: {{ $.global.providerSpecific.vcenter.server }}
+thumbprint: {{ $.global.providerSpecific.vcenter.thumbprint }}
 {{ toYaml .currentClass }}
 {{- end -}}
 

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -47,11 +47,11 @@ spec:
       config:
         enabled: true
         clusterId: {{ include "resource.default.name" $ }}
-        vcenter: "{{ .Values.vcenter.server }}"
-        datacenter: "{{ .Values.vcenter.datacenter }}"
-        region: "{{ .Values.vcenter.region }}"
-        zone: "{{ .Values.vcenter.zone }}"
-        thumbprint: "{{ .Values.vcenter.thumbprint }}"
+        vcenter: "{{ .Values.global.providerSpecific.vcenter.server }}"
+        datacenter: "{{ .Values.global.providerSpecific.vcenter.datacenter }}"
+        region: "{{ .Values.global.providerSpecific.vcenter.region }}"
+        zone: "{{ .Values.global.providerSpecific.vcenter.zone }}"
+        thumbprint: "{{ .Values.global.providerSpecific.vcenter.thumbprint }}"
       podSecurityStandards:
         enforced: {{ .Values.global.podSecurityStandards.enforced }}
     kube-vip-cloud-provider:

--- a/helm/cluster-vsphere/templates/kubeadmconfigtemplate.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmconfigtemplate.yaml
@@ -1,4 +1,4 @@
-{{- range $name, $value := .Values.nodePools }}
+{{- range $name, $value := .Values.global.nodePools }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/helm/cluster-vsphere/templates/machinedeployment.yaml
+++ b/helm/cluster-vsphere/templates/machinedeployment.yaml
@@ -1,4 +1,4 @@
-{{- range $name, $value := .Values.nodePools }}
+{{- range $name, $value := .Values.global.nodePools }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/helm/cluster-vsphere/templates/provider-secret.yaml
+++ b/helm/cluster-vsphere/templates/provider-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
 data:
-  username: {{ .Values.vcenter.username | b64enc | quote }}
-  password: {{ .Values.vcenter.password | b64enc | quote }}
+  username: {{ .Values.global.providerSpecific.vcenter.username | b64enc | quote }}
+  password: {{ .Values.global.providerSpecific.vcenter.password | b64enc | quote }}
   # https://github.com/fluxcd/flux2/issues/2625
-  escapedPassword: {{ .Values.vcenter.password | replace "." "\\." | replace "," "\\," | b64enc | quote }}
+  escapedPassword: {{ .Values.global.providerSpecific.vcenter.password | replace "." "\\." | replace "," "\\," | b64enc | quote }}

--- a/helm/cluster-vsphere/templates/vspherecluster.yaml
+++ b/helm/cluster-vsphere/templates/vspherecluster.yaml
@@ -14,5 +14,5 @@ spec:
   identityRef:
     kind: Secret
     name: {{ include "credentialSecretName" $ }}
-  server: {{ .Values.vcenter.server }}
-  thumbprint: {{ .Values.vcenter.thumbprint }}
+  server: {{ .Values.global.providerSpecific.vcenter.server }}
+  thumbprint: {{ .Values.global.providerSpecific.vcenter.thumbprint }}

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -264,6 +264,9 @@
 					}
 				},
 				"controlPlane": {
+					"type": "object",
+					"title": "Control plane",
+					"additionalProperties": false,
 					"properties": {
 						"dns": {
 							"type": "object",
@@ -313,7 +316,7 @@
 						},
 						"machineTemplate": {
 							"type": "object",
-							"title": "Machine template for control plane nodes.",
+							"title": "Template to define control plane nodes",
 							"additionalProperties": false,
 							"required": [
 								"network"
@@ -326,16 +329,18 @@
 									"default": "linkedClone"
 								},
 								"diskGiB": {
-									"type": "number",
+									"type": "integer",
 									"title": "Disk size",
 									"description": "Control plane node root volume size, in GB.",
-									"default": "50"
+									"default": 50,
+									"minimum": 50
 								},
 								"memoryMiB": {
-									"type": "number",
+									"type": "integer",
 									"title": "Memory size",
 									"description": "Control plane memory size, in MB.",
-									"default": "8192"
+									"default": 8192,
+									"minimum": 8192
 								},
 								"network": {
 									"type": "object",
@@ -372,15 +377,16 @@
 									}
 								},
 								"numCPUs": {
-									"type": "number",
+									"type": "integer",
 									"title": "Number of CPUs",
 									"description": "Control plane CPU count.",
-									"default": "4"
+									"default": 4,
+									"minimum": 4
 								},
 								"resourcePool": {
 									"type": "string",
 									"title": "Resource pool name",
-									"description": "vSphere resource pool name."
+									"description": "Name of the resource pool to use."
 								},
 								"template": {
 									"type": "string",
@@ -392,13 +398,15 @@
 						},
 						"replicas": {
 							"title": "Number of nodes",
-							"type": "integer"
+							"type": "integer",
+							"minimum": 1
 						},
 						"resourceRatio": {
+							"type": "integer",
 							"title": "Resource ratio",
 							"description": "Ratio between node resources and apiserver resource requests.",
 							"default": 8,
-							"type": "integer"
+							"minimum": 8
 						},
 						"oidc": {
 							"type": "object",
@@ -448,9 +456,7 @@
 								}
 							}
 						}
-					},
-					"title": "Control plane",
-					"type": "object"
+					}
 				},
 				"metadata": {
 					"type": "object",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -43,6 +43,231 @@
 					"title": "Connectivity",
 					"description": "Configurations related to cluster connectivity such as container registries.",
 					"required": [
+						"network"
+					],
+					"additionalProperties": false,
+					"properties": {
+						"baseDomain": {
+							"type": "string",
+							"title": "Base DNS domain",
+							"default": "k8s.test"
+						},
+						"containerRegistries": {
+							"type": "object",
+							"title": "Container registries",
+							"description": "Endpoints and credentials configuration for container registries.",
+							"additionalProperties": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"required": [
+										"endpoint"
+									],
+									"additionalProperties": false,
+									"properties": {
+										"credentials": {
+											"type": "object",
+											"title": "Credentials",
+											"description": "Credentials for the endpoint.",
+											"additionalProperties": false,
+											"properties": {
+												"auth": {
+													"type": "string",
+													"title": "Auth",
+													"description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
+												},
+												"identitytoken": {
+													"type": "string",
+													"title": "Identity token",
+													"description": "Used to authenticate the user and obtain an access token for the registry."
+												},
+												"password": {
+													"type": "string",
+													"title": "Password",
+													"description": "Used to authenticate for the registry with username/password."
+												},
+												"username": {
+													"type": "string",
+													"title": "Username",
+													"description": "Used to authenticate for the registry with username/password."
+												}
+											}
+										},
+										"endpoint": {
+											"type": "string",
+											"title": "Endpoint",
+											"description": "Endpoint for the container registry."
+										}
+									}
+								}
+							},
+							"default": {}
+						},
+						"network": {
+							"properties": {
+								"controlPlaneEndpoint": {
+									"description": "Kubernetes API configuration.",
+									"properties": {
+										"host": {
+											"title": "Host",
+											"description": "IP for access to the Kubernetes API. Manually select an IP for kube API. Empty string for auto selection from the ipPoolName pool.",
+											"type": "string"
+										},
+										"port": {
+											"title": "Port number",
+											"description": "Port for access to the Kubernetes API.",
+											"type": "integer"
+										},
+										"ipPoolName": {
+											"title": "Ip Pool Name",
+											"description": "Ip for control plane will be drawn from this GlobalInClusterIPPool resource.",
+											"type": "string",
+											"pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+											"default": "wc-cp-ips"
+										}
+									},
+									"title": "Endpoint",
+									"type": "object"
+								},
+								"pods": {
+									"properties": {
+										"cidrBlocks": {
+											"$ref": "#/$defs/cidrBlocks",
+											"default": "10.244.0.0/16",
+											"title": "Pod subnets"
+										}
+									},
+									"required": [
+										"cidrBlocks"
+									],
+									"title": "Pods",
+									"type": "object"
+								},
+								"services": {
+									"properties": {
+										"cidrBlocks": {
+											"$ref": "#/$defs/cidrBlocks",
+											"default": "172.31.0.0/16",
+											"title": "Service subnets"
+										}
+									},
+									"required": [
+										"cidrBlocks"
+									],
+									"title": "Services",
+									"type": "object"
+								},
+								"loadBalancers": {
+									"anyOf": [
+										{
+											"properties": {
+												"cidrBlocks": {
+													"$ref": "#/$defs/cidrBlocks",
+													"title": "Load Balancer subnets"
+												}
+											},
+											"required": ["cidrBlocks"]
+										},
+										{
+											"properties": {
+												"ipPoolName": {
+													"title": "Ip Pool Name",
+													"description": "Ip for Service LB running in WC will be drawn from this GlobalInClusterIPPool resource.",
+													"type": "string",
+													"pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+												}
+											},
+											"required": ["ipPoolName"]
+										}
+									],
+									"title": "Load balancers",
+									"type": "object"
+								}
+							},
+							"required": [
+								"pods",
+								"services",
+								"loadBalancers"
+							],
+							"title": "Network",
+							"type": "object"
+						},
+						"proxy": {
+							"type": "object",
+							"title": "Proxy",
+							"description": "Whether/how outgoing traffic is routed through proxy servers.",
+							"additionalProperties": false,
+							"properties": {
+								"enabled": {
+									"type": "boolean",
+									"title": "Enable"
+								},
+								"secretName": {
+									"type": "string",
+									"title": "Secret name",
+									"description": "Name of a secret resource used by containerd to obtain the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables. If empty the value will be defaulted to <clusterName>-cluster-values.",
+									"pattern": "^[a-z0-9-]{0,63}$"
+								}
+							}
+						},
+						"shell": {
+							"type": "object",
+							"title": "Shell access",
+							"additionalProperties": false,
+							"properties": {
+								"osUsers": {
+									"type": "array",
+									"title": "OS Users",
+									"description": "Configuration for OS users in cluster nodes.",
+									"items": {
+										"type": "object",
+										"title": "User",
+										"required": [
+											"name"
+										],
+										"additionalProperties": false,
+										"properties": {
+											"name": {
+												"type": "string",
+												"title": "Name",
+												"description": "Username of the user.",
+												"minLength": 2,
+												"pattern": "^[a-z][-a-z0-9]+$"
+											},
+											"sudo": {
+												"type": "string",
+												"title": "Sudoers configuration",
+												"description": "Permissions string to add to /etc/sudoers for this user."
+											}
+										}
+									},
+									"default": [
+										{
+											"name": "giantswarm",
+											"sudo": "ALL=(ALL) NOPASSWD:ALL"
+										}
+									]
+								},
+								"sshTrustedUserCAKeys": {
+									"type": "array",
+									"title": "Trusted SSH cert issuers",
+									"description": "CA certificates of issuers that are trusted to sign SSH user certificates.",
+									"items": {
+										"type": "string"
+									},
+									"default": [
+										"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
+									]
+								}
+							}
+						}
+					}
+				},		
+				"metadata": {
+					"type": "object",
+					"title": "Connectivity",
+					"description": "Configurations related to cluster connectivity such as container registries.",
+					"required": [
 						"baseDomain",
 						"network"
 					],

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -1243,53 +1243,6 @@
 			"title": "Node template",
 			"type": "object"
 		},
-		"vcenter": {
-			"description": "Configuration for vSphere API access.",
-			"properties": {
-				"datacenter": {
-					"description": "Name of the datacenter to deploy nodes into.",
-					"title": "Datacenter",
-					"type": "string"
-				},
-				"datastore": {
-					"description": "Name of the datastore for node disk storage.",
-					"title": "Datastore",
-					"type": "string"
-				},
-				"server": {
-					"description": "URL of the VSphere API.",
-					"title": "Server",
-					"type": "string"
-				},
-				"username": {
-					"description": "Username for the VSphere API.",
-					"title": "Username",
-					"type": "string"
-				},
-				"password": {
-					"description": "Password for the VSphere API.",
-					"title": "Password",
-					"type": "string"
-				},
-				"thumbprint": {
-					"description": "TLS certificate signature of the VSphere API.",
-					"title": "Thumbprint",
-					"type": "string"
-				},
-				"region": {
-					"description": "Category name in VSphere for topology.kubernetes.io/region labels.",
-					"title": "Region",
-					"type": "string"
-				},
-				"zone": {
-					"description": "Category name in VSphere for topology.kubernetes.io/zone labels.",
-					"title": "Zone",
-					"type": "string"
-				}
-			},
-			"title": "VCenter",
-			"type": "object"
-		},
 		"worker": {
 			"properties": {
 				"replicas": {

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -43,6 +43,7 @@
 					"title": "Connectivity",
 					"description": "Configurations related to cluster connectivity such as container registries.",
 					"required": [
+						"baseDomain",
 						"network"
 					],
 					"additionalProperties": false,

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -333,7 +333,7 @@
 									"title": "Disk size",
 									"description": "Control plane node root volume size, in GB.",
 									"default": 50,
-									"minimum": 50
+									"minimum": 25
 								},
 								"memoryMiB": {
 									"type": "integer",
@@ -381,7 +381,7 @@
 									"title": "Number of CPUs",
 									"description": "Control plane CPU count.",
 									"default": 4,
-									"minimum": 4
+									"minimum": 2
 								},
 								"resourcePool": {
 									"type": "string",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -500,6 +500,53 @@
 						}
 					}
 				},
+				"nodePools": {
+					"type": "object",
+					"title": "Node pools",
+					"description": "Groups of worker nodes with identical configuration.",
+					"additionalProperties": false,
+					"patternProperties": {
+						"^[a-z0-9-]{3,10}$": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"class": {
+									"type": "string",
+									"title": "Node class",
+									"description": "A valid node class name.",
+									"pattern": "^[a-z0-9-]+$"
+								},
+								"replicas": {
+									"type": "integer",
+									"title": "Number of nodes",
+									"default": 1,
+									"minimum": 1
+								}
+							}
+						}
+					},
+					"properties": {
+						"worker": {
+							"type": "object",
+							"title": "Default nodePool",
+							"additionalProperties": false,
+							"properties": {
+								"class": {
+									"type": "string",
+									"title": "Node class",
+									"description": "A valid node class name.",
+									"default": "default"
+								},
+								"replicas": {
+									"type": "integer",
+									"title": "Number of nodes",
+									"default": 2,
+									"minimum": 1
+								}
+							}
+						}
+					}
+				},
 				"podSecurityStandards": {
 					"type": "object",
 					"title": "Pod Security Standards",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -43,7 +43,6 @@
 					"title": "Connectivity",
 					"description": "Configurations related to cluster connectivity such as container registries.",
 					"required": [
-						"baseDomain",
 						"network"
 					],
 					"additionalProperties": false,

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -978,6 +978,58 @@
 							"default": true
 						}
 					}
+				},
+				"providerSpecific": {
+					"type": "object",
+					"properties": {
+						"vcenter": {
+							"description": "Configuration for vSphere API access.",
+							"properties": {
+								"datacenter": {
+									"description": "Name of the datacenter to deploy nodes into.",
+									"title": "Datacenter",
+									"type": "string"
+								},
+								"datastore": {
+									"description": "Name of the datastore for node disk storage.",
+									"title": "Datastore",
+									"type": "string"
+								},
+								"server": {
+									"description": "URL of the VSphere API.",
+									"title": "Server",
+									"type": "string"
+								},
+								"username": {
+									"description": "Username for the VSphere API.",
+									"title": "Username",
+									"type": "string"
+								},
+								"password": {
+									"description": "Password for the VSphere API.",
+									"title": "Password",
+									"type": "string"
+								},
+								"thumbprint": {
+									"description": "TLS certificate signature of the VSphere API.",
+									"title": "Thumbprint",
+									"type": "string"
+								},
+								"region": {
+									"description": "Category name in VSphere for topology.kubernetes.io/region labels.",
+									"title": "Region",
+									"type": "string"
+								},
+								"zone": {
+									"description": "Category name in VSphere for topology.kubernetes.io/zone labels.",
+									"title": "Zone",
+									"type": "string"
+								}
+							},
+							"title": "VCenter",
+							"type": "object"
+						}
+					}
 				}
 			}
 		},

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -49,8 +49,7 @@
 					"properties": {
 						"baseDomain": {
 							"type": "string",
-							"title": "Base DNS domain",
-							"default": "k8s.test"
+							"title": "Base DNS domain"
 						},
 						"containerRegistries": {
 							"type": "object",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -262,7 +262,196 @@
 							}
 						}
 					}
-				},		
+				},
+				"controlPlane": {
+					"properties": {
+						"dns": {
+							"type": "object",
+							"title": "DNS container image",
+							"additionalProperties": false,
+							"properties": {
+								"imageRepository": {
+									"type": "string",
+									"title": "Repository",
+									"default": "gsoci.azurecr.io/giantswarm"
+								},
+								"imageTag": {
+									"type": "string",
+									"title": "Tag",
+									"default": "1.9.4-giantswarm"
+								}
+							}
+						},
+						"etcd": {
+							"type": "object",
+							"title": "Etcd container image",
+							"additionalProperties": false,
+							"properties": {
+								"imageRepository": {
+									"type": "string",
+									"title": "Repository",
+									"default": "gsoci.azurecr.io/giantswarm"
+								},
+								"imageTag": {
+									"type": "string",
+									"title": "Tag",
+									"default": "3.5.4-0-k8s"
+								}
+							}
+						},
+						"image": {
+							"type": "object",
+							"title": "Node container image",
+							"additionalProperties": false,
+							"properties": {
+								"repository": {
+									"type": "string",
+									"title": "Repository",
+									"default": "gsoci.azurecr.io/giantswarm"
+								}
+							}
+						},
+						"machineTemplate": {
+							"type": "object",
+							"title": "Machine template for control plane nodes.",
+							"additionalProperties": false,
+							"required": [
+								"network"
+							],
+							"properties": {
+								"cloneMode": {
+									"type": "string",
+									"title": "Template clone mode",
+									"description": "VM template cloning method.",
+									"default": "linkedClone"
+								},
+								"diskGiB": {
+									"type": "number",
+									"title": "Disk size",
+									"description": "Control plane node root volume size, in GB.",
+									"default": "50"
+								},
+								"memoryMiB": {
+									"type": "number",
+									"title": "Memory size",
+									"description": "Control plane memory size, in MB.",
+									"default": "8192"
+								},
+								"network": {
+									"type": "object",
+									"title": "Network configuration",
+									"description": "Control plane node network configuration.",
+									"additionalProperties": false,
+									"properties": {
+										"devices": {
+											"type": "array",
+											"title": "Network devices",
+											"description": "Control plane node network devices.",
+											"additionalProperties": false,
+											"items": {
+												"type": "object",
+												"title": "Devices",
+												"required": [
+													"networkName"
+												],
+												"additionalProperties": false,
+												"properties": {
+													"dhcp4": {
+														"type": "boolean",
+														"title": "IPv4 DHCP",
+														"description": "Is DHCP enabled on this segment."
+													},
+													"networkName": {
+														"type": "string",
+														"title": "Segment name",
+														"description": "Segment name to attach nodes to. Must already exist."
+													}
+												}
+											}
+										}
+									}
+								},
+								"numCPUs": {
+									"type": "number",
+									"title": "Number of CPUs",
+									"description": "Control plane CPU count.",
+									"default": "4"
+								},
+								"resourcePool": {
+									"type": "string",
+									"title": "Resource pool name",
+									"description": "vSphere resource pool name."
+								},
+								"template": {
+									"type": "string",
+									"title": "VM template",
+									"description": "Full name of the VM template.",
+									"default": "flatcar-stable-3602.2.1-kube-v1.25.16-gs"
+								}
+							}
+						},
+						"replicas": {
+							"title": "Number of nodes",
+							"type": "integer"
+						},
+						"resourceRatio": {
+							"title": "Resource ratio",
+							"description": "Ratio between node resources and apiserver resource requests.",
+							"default": 8,
+							"type": "integer"
+						},
+						"oidc": {
+							"type": "object",
+							"title": "OIDC authentication",
+							"required": [
+								"clientId",
+								"groupsClaim",
+								"issuerUrl",
+								"usernameClaim"
+							],
+							"additionalProperties": false,
+							"properties": {
+								"caFile": {
+									"type": "string",
+									"title": "Certificate authority file",
+									"description": "Path to identity provider's CA certificate in PEM format."
+								},
+								"clientId": {
+									"type": "string",
+									"title": "Client ID",
+									"description": "OIDC client identifier to identify with."
+								},
+								"groupsClaim": {
+									"type": "string",
+									"title": "Groups claim",
+									"description": "Name of the identity token claim bearing the user's group memberships."
+								},
+								"groupsPrefix": {
+									"type": "string",
+									"title": "Groups prefix",
+									"description": "Prefix prepended to groups values to prevent clashes with existing names."
+								},
+								"issuerUrl": {
+									"type": "string",
+									"title": "Issuer URL",
+									"description": "URL of the provider which allows the API server to discover public signing keys, not including any path. Discovery URL without the '/.well-known/openid-configuration' part."
+								},
+								"usernameClaim": {
+									"type": "string",
+									"title": "Username claim",
+									"description": "Name of the identity token claim bearing the unique user identifier."
+								},
+								"usernamePrefix": {
+									"type": "string",
+									"title": "Username prefix",
+									"description": "Prefix prepended to username values to prevent clashes with existing names."
+								}
+							}
+						}
+					},
+					"title": "Control plane",
+					"type": "object"
+				},
 				"metadata": {
 					"type": "object",
 					"title": "Connectivity",

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -12,6 +12,7 @@ controllerManager:
 
 global:
   connectivity:
+    baseDomain: k8s.test
     containerRegistries: {}
     network:
       controlPlaneEndpoint:

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -12,7 +12,6 @@ controllerManager:
 
 global:
   connectivity:
-    containerRegistries: {}
     network:
       controlPlaneEndpoint:
         host: ""

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -12,7 +12,6 @@ controllerManager:
 
 global:
   connectivity:
-    baseDomain: k8s.test
     containerRegistries: {}
     network:
       controlPlaneEndpoint:

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -58,6 +58,16 @@ global:
       replicas: 2
   podSecurityStandards:
     enforced: true
+  providerSpecific:
+    vcenter:
+      datacenter: ""
+      username: ""
+      password: ""
+      datastore: ""
+      server: ""
+      thumbprint: ""
+      region: ""
+      zone: ""
   metadata:
     description: ""
     labels: {}
@@ -94,14 +104,3 @@ nodeClasses:
       devices:
       - networkName: ""
         dhcp4: true
-
-
-vcenter:
-  datacenter: ""
-  username: ""
-  password: ""
-  datastore: ""
-  server: ""
-  thumbprint: ""
-  region: ""
-  zone: ""

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -91,10 +91,6 @@ nodeClasses:
       - networkName: ""
         dhcp4: true
 
-nodePools:
-  worker:
-    class: default
-    replicas: 2
 
 vcenter:
   datacenter: ""

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -52,6 +52,10 @@ global:
       template: flatcar-stable-3602.2.1-kube-v1.25.16-gs
     oidc: {}
     resourceRatio: 8
+  nodePools:
+    worker:
+      class: default
+      replicas: 2
   podSecurityStandards:
     enforced: true
   metadata:

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -12,6 +12,7 @@ controllerManager:
 
 global:
   connectivity:
+    containerRegistries: {}
     network:
       controlPlaneEndpoint:
         host: ""


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/3372


Notes: 

- it's not possible to test this using the e2e CI tests because the [test cluster values](https://github.com/giantswarm/cluster-standup-teardown/blob/main/pkg/clusterbuilder/providers/capv/values/cluster_values.yaml) have not been updated yet (and cannot be updated until the chart refactoring is complete and released). Running the CI tests locally with manually updated values passes though:

```
ADD TEST OUTPUT
```


