### PR TITLE
refactor: create providerSpecific key under global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
     with(select(.controlPlane != null);             .global.controlPlane = .controlPlane) |
     with(select(.oidc != null);                     .global.controlPlane.oidc = .oidc) |
     with(select(.nodePools != null);                .global.nodePools = .nodePools) |
+    with(select(.vcenter != null);                  .global.providerSpecific.vcenter = .vcenter) |
 
     del(.metadata) |
     del(.clusterDescription) |
@@ -42,7 +43,8 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
     del(.baseDomain) |
     del(.controlPlane) |
     del(.oidc) |
-    del(.nodePools)' values.yaml
+    del(.nodePools) |
+    del(.vcenter)' values.yaml
 ```
 
 </details>
@@ -62,6 +64,7 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
 - Move Helm values property `.Values.controlPlane` to `.Values.global.controlPlane`.
 - Move Helm values property `.Values.oidc` to `.Values.global.controlPlane.oidc`.
 - Move Helm values property `.Values.nodePools` to `.Values.global.nodePools`.
+- Move Helm values property `.Values.vcenter` to `.Values.global.providerSpecific.vcenter`.
 
 ## [0.50.0] - 2024-04-23
 

--- a/helm/cluster-vsphere/ci/ci-values.yaml
+++ b/helm/cluster-vsphere/ci/ci-values.yaml
@@ -2,16 +2,6 @@ cluster:
   name: test
   kubernetesVersion: "v1.24.11"
   enableEncryptionProvider: false
-vcenter:
-  server: "https://foo.example.com"
-  username: "vcenter-admin"
-  password: "vcenter-admin-password"
-  datacenter: "Datacenter"
-  datastore: "vsanDatastore"
-  # openssl s_client -connect https://foo.example.com < /dev/null 2>/dev/null | openssl x509 -fingerprint -noout -in /dev/stdin
-  thumbprint: "F7:CF:F9:E5:99:39:FF:C1:D7:14:F1:3F:8A:42:21:95:3B:A1:6E:16"
-  region: "k8s-region"
-  zone: "k8s-zone"
 nodeClasses:
   default:
     template: "ubuntu-2004-kube-v1.24.11"
@@ -54,3 +44,14 @@ global:
     worker:
       class: "default"
       replicas: 2
+  providerSpecific:
+    vcenter:
+      server: "https://foo.example.com"
+      username: "vcenter-admin"
+      password: "vcenter-admin-password"
+      datacenter: "Datacenter"
+      datastore: "vsanDatastore"
+      # openssl s_client -connect https://foo.example.com < /dev/null 2>/dev/null | openssl x509 -fingerprint -noout -in /dev/stdin
+      thumbprint: "F7:CF:F9:E5:99:39:FF:C1:D7:14:F1:3F:8A:42:21:95:3B:A1:6E:16"
+      region: "k8s-region"
+      zone: "k8s-zone"

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -24,10 +24,10 @@ Here we are generating a hash suffix to trigger upgrade when only it is necessar
 using only the parameters used in vspheredmachinetemplate.yaml.
 */}}
 {{- define "mtSpec" -}}
-datacenter: {{ $.vcenter.datacenter }}
-datastore: {{ $.vcenter.datastore }}
-server: {{ $.vcenter.server }}
-thumbprint: {{ $.vcenter.thumbprint }}
+datacenter: {{ $.global.providerSpecific.vcenter.datacenter }}
+datastore: {{ $.global.providerSpecific.vcenter.datastore }}
+server: {{ $.global.providerSpecific.vcenter.server }}
+thumbprint: {{ $.global.providerSpecific.vcenter.thumbprint }}
 {{ toYaml .currentClass }}
 {{- end -}}
 

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -47,11 +47,11 @@ spec:
       config:
         enabled: true
         clusterId: {{ include "resource.default.name" $ }}
-        vcenter: "{{ .Values.vcenter.server }}"
-        datacenter: "{{ .Values.vcenter.datacenter }}"
-        region: "{{ .Values.vcenter.region }}"
-        zone: "{{ .Values.vcenter.zone }}"
-        thumbprint: "{{ .Values.vcenter.thumbprint }}"
+        vcenter: "{{ .Values.global.providerSpecific.vcenter.server }}"
+        datacenter: "{{ .Values.global.providerSpecific.vcenter.datacenter }}"
+        region: "{{ .Values.global.providerSpecific.vcenter.region }}"
+        zone: "{{ .Values.global.providerSpecific.vcenter.zone }}"
+        thumbprint: "{{ .Values.global.providerSpecific.vcenter.thumbprint }}"
       podSecurityStandards:
         enforced: {{ .Values.global.podSecurityStandards.enforced }}
     kube-vip-cloud-provider:

--- a/helm/cluster-vsphere/templates/provider-secret.yaml
+++ b/helm/cluster-vsphere/templates/provider-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
 data:
-  username: {{ .Values.vcenter.username | b64enc | quote }}
-  password: {{ .Values.vcenter.password | b64enc | quote }}
+  username: {{ .Values.global.providerSpecific.vcenter.username | b64enc | quote }}
+  password: {{ .Values.global.providerSpecific.vcenter.password | b64enc | quote }}
   # https://github.com/fluxcd/flux2/issues/2625
-  escapedPassword: {{ .Values.vcenter.password | replace "." "\\." | replace "," "\\," | b64enc | quote }}
+  escapedPassword: {{ .Values.global.providerSpecific.vcenter.password | replace "." "\\." | replace "," "\\," | b64enc | quote }}

--- a/helm/cluster-vsphere/templates/vspherecluster.yaml
+++ b/helm/cluster-vsphere/templates/vspherecluster.yaml
@@ -14,5 +14,5 @@ spec:
   identityRef:
     kind: Secret
     name: {{ include "credentialSecretName" $ }}
-  server: {{ .Values.vcenter.server }}
-  thumbprint: {{ .Values.vcenter.thumbprint }}
+  server: {{ .Values.global.providerSpecific.vcenter.server }}
+  thumbprint: {{ .Values.global.providerSpecific.vcenter.thumbprint }}

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -558,6 +558,58 @@
 							"default": true
 						}
 					}
+				},
+				"providerSpecific": {
+					"type": "object",
+					"properties": {
+						"vcenter": {
+							"description": "Configuration for vSphere API access.",
+							"properties": {
+								"datacenter": {
+									"description": "Name of the datacenter to deploy nodes into.",
+									"title": "Datacenter",
+									"type": "string"
+								},
+								"datastore": {
+									"description": "Name of the datastore for node disk storage.",
+									"title": "Datastore",
+									"type": "string"
+								},
+								"server": {
+									"description": "URL of the VSphere API.",
+									"title": "Server",
+									"type": "string"
+								},
+								"username": {
+									"description": "Username for the VSphere API.",
+									"title": "Username",
+									"type": "string"
+								},
+								"password": {
+									"description": "Password for the VSphere API.",
+									"title": "Password",
+									"type": "string"
+								},
+								"thumbprint": {
+									"description": "TLS certificate signature of the VSphere API.",
+									"title": "Thumbprint",
+									"type": "string"
+								},
+								"region": {
+									"description": "Category name in VSphere for topology.kubernetes.io/region labels.",
+									"title": "Region",
+									"type": "string"
+								},
+								"zone": {
+									"description": "Category name in VSphere for topology.kubernetes.io/zone labels.",
+									"title": "Zone",
+									"type": "string"
+								}
+							},
+							"title": "VCenter",
+							"type": "object"
+						}
+					}
 				}
 			}
 		},

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -823,53 +823,6 @@
 			"title": "Node template",
 			"type": "object"
 		},
-		"vcenter": {
-			"description": "Configuration for vSphere API access.",
-			"properties": {
-				"datacenter": {
-					"description": "Name of the datacenter to deploy nodes into.",
-					"title": "Datacenter",
-					"type": "string"
-				},
-				"datastore": {
-					"description": "Name of the datastore for node disk storage.",
-					"title": "Datastore",
-					"type": "string"
-				},
-				"server": {
-					"description": "URL of the VSphere API.",
-					"title": "Server",
-					"type": "string"
-				},
-				"username": {
-					"description": "Username for the VSphere API.",
-					"title": "Username",
-					"type": "string"
-				},
-				"password": {
-					"description": "Password for the VSphere API.",
-					"title": "Password",
-					"type": "string"
-				},
-				"thumbprint": {
-					"description": "TLS certificate signature of the VSphere API.",
-					"title": "Thumbprint",
-					"type": "string"
-				},
-				"region": {
-					"description": "Category name in VSphere for topology.kubernetes.io/region labels.",
-					"title": "Region",
-					"type": "string"
-				},
-				"zone": {
-					"description": "Category name in VSphere for topology.kubernetes.io/zone labels.",
-					"title": "Zone",
-					"type": "string"
-				}
-			},
-			"title": "VCenter",
-			"type": "object"
-		},
 		"worker": {
 			"properties": {
 				"replicas": {

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -54,6 +54,16 @@ global:
     resourceRatio: 8
   podSecurityStandards:
     enforced: true
+  providerSpecific:
+    vcenter:
+      datacenter: ""
+      username: ""
+      password: ""
+      datastore: ""
+      server: ""
+      thumbprint: ""
+      region: ""
+      zone: ""
   metadata:
     description: ""
     labels: {}
@@ -90,14 +100,3 @@ nodeClasses:
       devices:
       - networkName: ""
         dhcp4: true
-
-
-vcenter:
-  datacenter: ""
-  username: ""
-  password: ""
-  datastore: ""
-  server: ""
-  thumbprint: ""
-  region: ""
-  zone: ""


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/3372


Notes: 

- it's not possible to test this using the e2e CI tests because the [test cluster values](https://github.com/giantswarm/cluster-standup-teardown/blob/main/pkg/clusterbuilder/providers/capv/values/cluster_values.yaml) have not been updated yet (and cannot be updated until the chart refactoring is complete and released). Running the CI tests locally with manually updated values passes though:

```
Ran 18 of 27 Specs in 2174.162 seconds
SUCCESS! -- 18 Passed | 0 Failed | 0 Pending | 9 Skipped
PASS

Ginkgo ran 1 suite in 36m22.416968005s
Test Suite Passed
```
