### PR TITLE
refactor: aggregate remaining values under internal"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ yq eval --inplace 'with(select(.metadata != null);          .global.metadata = .
     with(select(.apiServer.enableAdmissionPlugins != null); .internal.apiServer.enableAdmissionPlugins = (.apiServer.enableAdmissionPlugins | split(","))) |
     with(select(.apiServer.featureGates != null);           .internal.apiServer.featureGates = (.apiServer.featureGates | split(","))) |
     with(select(.apiServer.certSANs != null);               .internal.certSANs = .apiServer.certSANs) |
+    with(select(.kubectlImage != null);                     .internal.kubectlImage = .kubectlImage) |
+    with(select(.nodeClasses != null);                      .global.nodeClasses = .nodeClasses) |
 
     del(.metadata) |
     del(.clusterDescription) |
@@ -53,7 +55,9 @@ yq eval --inplace 'with(select(.metadata != null);          .global.metadata = .
     del(.vcenter) |
     del(.cluster) |
     del(.controllerManager) |
-    del(.apiServer)' values.yaml
+    del(.apiServer) |
+    del(.kubectlImage) |
+    del(.nodeClasses)' values.yaml
 ```
 
 </details>
@@ -78,6 +82,8 @@ yq eval --inplace 'with(select(.metadata != null);          .global.metadata = .
 - Move Helm values property `.Values.apiServer.enableAdmissionPlugins` to `.Values.internal.apiServer.enableAdmissionPlugins` and convert from string to array.
 - Move Helm values property `.Values.apiServer.featureGates` to `.Values.internal.apiServer.featureGates` and convert from string to array.
 - Move Helm values property `.Values.apiServer.certSANs` to `.Values.internal.apiServer.certSANs`.
+- Move Helm values property `.Values.kubectlImage` to `.Values.internal.kubectlImage`.
+- Move Helm values property `.Values.nodeClasses` to `.Values.global.nodeClasses`.
 
 ## [0.50.0] - 2024-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,20 +16,26 @@ Using `yq`, migrate to the new values layout with the following command:
 
 ```bash
 #!/bin/bash
-yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata) |
-    with(select(.clusterDescription != null);       .global.metadata.description = .clusterDescription) |
-    with(select(.organization != null);             .global.metadata.organization = .organization) |
-    with(select(.clusterLabels != null);            .global.metadata.labels = .clusterLabels) |
-    with(select(.servicePriority != null);          .global.metadata.servicePriority = .servicePriority) |
-    with(select(.connectivity != null);             .global.connectivity = .connectivity) |
-    with(select(.osUsers != null);                  .global.connectivity.shell.osUsers = .osUsers) |
-    with(select(.sshTrustedUserCAKeys != null);     .global.connectivity.shell.sshTrustedUserCAKeys = .sshTrustedUserCAKeys) |
-    with(select(.proxy != null);                    .global.connectivity.proxy = .proxy) |
-    with(select(.baseDomain != null);               .global.connectivity.baseDomain = .baseDomain) |
-    with(select(.controlPlane != null);             .global.controlPlane = .controlPlane) |
-    with(select(.oidc != null);                     .global.controlPlane.oidc = .oidc) |
-    with(select(.nodePools != null);                .global.nodePools = .nodePools) |
-    with(select(.vcenter != null);                  .global.providerSpecific.vcenter = .vcenter) |
+yq eval --inplace 'with(select(.metadata != null);          .global.metadata = .metadata) |
+    with(select(.clusterDescription != null);               .global.metadata.description = .clusterDescription) |
+    with(select(.organization != null);                     .global.metadata.organization = .organization) |
+    with(select(.clusterLabels != null);                    .global.metadata.labels = .clusterLabels) |
+    with(select(.servicePriority != null);                  .global.metadata.servicePriority = .servicePriority) |
+    with(select(.connectivity != null);                     .global.connectivity = .connectivity) |
+    with(select(.osUsers != null);                          .global.connectivity.shell.osUsers = .osUsers) |
+    with(select(.sshTrustedUserCAKeys != null);             .global.connectivity.shell.sshTrustedUserCAKeys = .sshTrustedUserCAKeys) |
+    with(select(.proxy != null);                            .global.connectivity.proxy = .proxy) |
+    with(select(.baseDomain != null);                       .global.connectivity.baseDomain = .baseDomain) |
+    with(select(.controlPlane != null);                     .global.controlPlane = .controlPlane) |
+    with(select(.oidc != null);                             .global.controlPlane.oidc = .oidc) |
+    with(select(.nodePools != null);                        .global.nodePools = .nodePools) |
+    with(select(.vcenter != null);                          .global.providerSpecific.vcenter = .vcenter) |
+    with(select(.cluster.kubernetesVersion != null);        .internal.kubernetesVersion = .cluster.kubernetesVersion) |
+    with(select(.cluster.enableEncryptionProvider != null); .internal.enableEncryptionProvider = .cluster.enableEncryptionProvider) |
+    with(select(.controllerManager.featureGates != null);   .internal.controllerManager.featureGates = (.controllerManager.featureGates | split(","))) |
+    with(select(.apiServer.enableAdmissionPlugins != null); .internal.apiServer.enableAdmissionPlugins = (.apiServer.enableAdmissionPlugins | split(","))) |
+    with(select(.apiServer.featureGates != null);           .internal.apiServer.featureGates = (.apiServer.featureGates | split(","))) |
+    with(select(.apiServer.certSANs != null);               .internal.certSANs = .apiServer.certSANs) |
 
     del(.metadata) |
     del(.clusterDescription) |
@@ -44,7 +50,10 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
     del(.controlPlane) |
     del(.oidc) |
     del(.nodePools) |
-    del(.vcenter)' values.yaml
+    del(.vcenter) |
+    del(.cluster) |
+    del(.controllerManager) |
+    del(.apiServer)' values.yaml
 ```
 
 </details>
@@ -65,6 +74,10 @@ yq eval --inplace 'with(select(.metadata != null);  .global.metadata = .metadata
 - Move Helm values property `.Values.oidc` to `.Values.global.controlPlane.oidc`.
 - Move Helm values property `.Values.nodePools` to `.Values.global.nodePools`.
 - Move Helm values property `.Values.vcenter` to `.Values.global.providerSpecific.vcenter`.
+- Move Helm values property `.Values.controllerManager.featureGates` to `.Values.internal.controllerManager.featureGates` and convert from string to array.
+- Move Helm values property `.Values.apiServer.enableAdmissionPlugins` to `.Values.internal.apiServer.enableAdmissionPlugins` and convert from string to array.
+- Move Helm values property `.Values.apiServer.featureGates` to `.Values.internal.apiServer.featureGates` and convert from string to array.
+- Move Helm values property `.Values.apiServer.certSANs` to `.Values.internal.apiServer.certSANs`.
 
 ## [0.50.0] - 2024-04-23
 

--- a/helm/cluster-vsphere/ci/ci-values.yaml
+++ b/helm/cluster-vsphere/ci/ci-values.yaml
@@ -1,15 +1,3 @@
-nodeClasses:
-  default:
-    template: "ubuntu-2004-kube-v1.24.11"
-    cloneMode: "linkedClone"
-    diskGiB: 25
-    numCPUs: 2
-    memoryMiB: 8192
-    resourcePool: "grasshopper"
-    network:
-      devices:
-        - networkName: 'grasshopper-capv'
-          dhcp4: true
 global:
   metadata:
     description: "test cluster"
@@ -51,6 +39,18 @@ global:
       thumbprint: "F7:CF:F9:E5:99:39:FF:C1:D7:14:F1:3F:8A:42:21:95:3B:A1:6E:16"
       region: "k8s-region"
       zone: "k8s-zone"
+  nodeClasses:
+    default:
+      template: "ubuntu-2004-kube-v1.24.11"
+      cloneMode: "linkedClone"
+      diskGiB: 25
+      numCPUs: 2
+      memoryMiB: 8192
+      resourcePool: "grasshopper"
+      network:
+        devices:
+          - networkName: 'grasshopper-capv'
+            dhcp4: true
 internal:
   kubernetesVersion: "v1.24.11"
   enableEncryptionProvider: false

--- a/helm/cluster-vsphere/ci/ci-values.yaml
+++ b/helm/cluster-vsphere/ci/ci-values.yaml
@@ -1,7 +1,3 @@
-cluster:
-  name: test
-  kubernetesVersion: "v1.24.11"
-  enableEncryptionProvider: false
 nodeClasses:
   default:
     template: "ubuntu-2004-kube-v1.24.11"
@@ -55,3 +51,6 @@ global:
       thumbprint: "F7:CF:F9:E5:99:39:FF:C1:D7:14:F1:3F:8A:42:21:95:3B:A1:6E:16"
       region: "k8s-region"
       zone: "k8s-zone"
+internal:
+  kubernetesVersion: "v1.24.11"
+  enableEncryptionProvider: false

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -154,7 +154,7 @@ postKubeadmCommands:
 
 {{- define "mtRevisionByClass" -}}
 {{- $outerScope := . }}
-{{- range $name, $value := .currentValues.nodeClasses }}
+{{- range $name, $value := .currentValues.global.nodeClasses }}
 {{- if eq $name $outerScope.class }}
 {{- include "mtRevision" (merge (dict "currentClass" $value) $outerScope.currentValues) }}
 {{- end }}

--- a/helm/cluster-vsphere/templates/helmreleases/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cleanup-helmreleases-hook-job.yaml
@@ -100,7 +100,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: post-delete-job
-          image: "{{ .Values.kubectlImage.registry }}/{{ .Values.kubectlImage.name }}:{{ .Values.kubectlImage.tag }}"
+          image: "{{ .Values.internal.kubectlImage.registry }}/{{ .Values.internal.kubectlImage.name }}:{{ .Values.internal.kubectlImage.tag }}"
           command:
             - "/bin/sh"
             - "-xc"

--- a/helm/cluster-vsphere/templates/ipam/_ipam.tpl
+++ b/helm/cluster-vsphere/templates/ipam/_ipam.tpl
@@ -41,7 +41,7 @@
 
 
 {{- define "ipamJobContainerCommon" -}}
-image: "{{ .Values.kubectlImage.registry }}/{{ .Values.kubectlImage.name }}:{{ .Values.kubectlImage.tag }}"
+image: "{{ .Values.internal.kubectlImage.registry }}/{{ .Values.internal.kubectlImage.name }}:{{ .Values.internal.kubectlImage.tag }}"
 securityContext:
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -15,7 +15,7 @@ spec:
         - localhost
         - 127.0.0.1
         - "api.{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}"
-        {{- with .Values.apiServer.certSANs }}
+        {{- with .Values.internal.apiServer.certSANs }}
         {{- range . }}
         - {{ . }}
         {{- end }}
@@ -27,11 +27,17 @@ spec:
           audit-log-path: /var/log/apiserver/audit.log
           audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
           cloud-provider: external
-          enable-admission-plugins: {{ .Values.apiServer.enableAdmissionPlugins }}
+          {{- if .Values.internal.apiServer.enableAdmissionPlugins }}
+          enable-admission-plugins: {{ .Values.internal.apiServer.enableAdmissionPlugins | join "," | quote }}
+          {{- end }}
           {{- if $.Values.internal.enableEncryptionProvider }}
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml
           {{- end }}
-          feature-gates: {{ .Values.apiServer.featureGates | quote }}
+          {{- if .Values.internal.apiServer.featureGates }}
+          feature-gates: {{ range $index, $element := .Values.internal.apiServer.featureGates -}}
+            {{ if $index }},{{ end }}{{ $element.name }}={{ $element.enabled }}
+          {{- end }}
+          {{- end }}
           kubelet-preferred-address-types: "InternalIP"
           {{- if .Values.global.controlPlane.oidc.issuerUrl }}
           {{- with .Values.global.controlPlane.oidc }}

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -74,7 +74,11 @@ spec:
           cloud-provider: external
           enable-hostpath-provisioner: "true"
           terminated-pod-gc-threshold: "125"
-          feature-gates: {{ .Values.controllerManager.featureGates | quote }}
+          {{- if .Values.internal.controllerManager.featureGates }}
+          feature-gates: {{ range $index, $element := .Values.internal.controllerManager.featureGates -}}
+            {{ if $index }},{{ end }}{{ $element.name }}={{ $element.enabled }}
+          {{- end }}
+          {{- end }}
           profiling: "false"
       etcd:
         local:

--- a/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-vsphere/templates/kubeadmcontrolplane.yaml
@@ -28,7 +28,7 @@ spec:
           audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
           cloud-provider: external
           enable-admission-plugins: {{ .Values.apiServer.enableAdmissionPlugins }}
-          {{- if $.Values.cluster.enableEncryptionProvider }}
+          {{- if $.Values.internal.enableEncryptionProvider }}
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml
           {{- end }}
           feature-gates: {{ .Values.apiServer.featureGates | quote }}
@@ -60,7 +60,7 @@ spec:
             hostPath: /etc/kubernetes/policies
             mountPath: /etc/kubernetes/policies
             pathType: DirectoryOrCreate
-          {{- if $.Values.cluster.enableEncryptionProvider }}
+          {{- if $.Values.internal.enableEncryptionProvider }}
           - name: encryption
             hostPath: /etc/kubernetes/encryption
             mountPath: /etc/kubernetes/encryption
@@ -128,7 +128,7 @@ spec:
         content: |-
           {{- $.Files.Get $kubeadmPatch | nindent 10 }}
       {{- end }}
-      {{- if $.Values.cluster.enableEncryptionProvider }}
+      {{- if $.Values.internal.enableEncryptionProvider }}
       - path: /etc/kubernetes/encryption/config.yaml
         permissions: "0600"
         contentFrom:
@@ -154,4 +154,4 @@ spec:
       name: {{ include "resource.default.name" . }}-control-plane-{{ include "mtRevisionByControlPlane" $ }}
       namespace: {{ .Release.Namespace }}
   replicas: {{ .Values.global.controlPlane.replicas }}
-  version: {{ .Values.cluster.kubernetesVersion }}
+  version: {{ .Values.internal.kubernetesVersion }}

--- a/helm/cluster-vsphere/templates/machinedeployment.yaml
+++ b/helm/cluster-vsphere/templates/machinedeployment.yaml
@@ -31,5 +31,5 @@ spec:
         kind: VSphereMachineTemplate
         name: {{ include "resource.default.name" $ }}-{{ $value.class }}-{{ include "mtRevisionByClass" (merge (dict "currentValues" $.Values) $value) }}
         namespace: {{ $.Release.Namespace }}
-      version: {{ $.Values.cluster.kubernetesVersion }}
+      version: {{ $.Values.internal.kubernetesVersion }}
 {{- end }}

--- a/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
+++ b/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
@@ -1,4 +1,4 @@
-{{- range $name, $value := (merge .Values.nodeClasses (dict "control-plane" .Values.global.controlPlane.machineTemplate)) }}
+{{- range $name, $value := (merge .Values.global.nodeClasses (dict "control-plane" .Values.global.controlPlane.machineTemplate)) }}
 {{- $c := (merge (dict "currentClass"  $value) $.Values) }}
 ---
 apiVersion: {{ include "infrastructureApiVersion" . }}

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -503,6 +503,92 @@
 						}
 					}
 				},
+				"nodeClasses": {
+					"type": "object",
+					"title": "Template to define control plane nodes",
+					"properties": {
+						"default": {
+							"type": "object",
+							"title": "Default node class configuration.",
+							"additionalProperties": false,
+							"properties": {
+								"cloneMode": {
+									"type": "string",
+									"title": "Template clone mode",
+									"description": "VM template cloning method.",
+									"default": "linkedClone"
+								},
+								"diskGiB": {
+									"type": "integer",
+									"title": "Disk size",
+									"description": "Control plane node root volume size, in GB.",
+									"default": 50,
+									"minimum": 25
+								},
+								"memoryMiB": {
+									"type": "integer",
+									"title": "Memory size",
+									"description": "Control plane memory size, in MB.",
+									"default": 16896,
+									"minimum": 8192
+								},
+								"network": {
+									"type": "object",
+									"title": "Network configuration",
+									"description": "Control plane node network configuration.",
+									"additionalProperties": false,
+									"properties": {
+										"devices": {
+											"type": "array",
+											"title": "Network devices",
+											"description": "Control plane node network devices.",
+											"additionalProperties": false,
+											"items": {
+												"type": "object",
+												"title": "Devices",
+												"required": [
+													"networkName"
+												],
+												"additionalProperties": false,
+												"properties": {
+													"dhcp4": {
+														"type": "boolean",
+														"title": "IPv4 DHCP",
+														"description": "Is DHCP enabled on this segment."
+													},
+													"networkName": {
+														"type": "string",
+														"title": "Segment name",
+														"description": "Segment name to attach nodes to. Must already exist."
+													}
+												}
+											}
+										}
+									}
+								},
+								"numCPUs": {
+									"type": "integer",
+									"title": "Number of CPUs",
+									"description": "Control plane CPU count.",
+									"default": 6,
+									"minimum": 2
+								},
+								"resourcePool": {
+									"type": "string",
+									"title": "Resource pool name",
+									"description": "Name of the resource pool to use."
+								},
+								"template": {
+									"type": "string",
+									"title": "VM template",
+									"description": "Full name of the VM template.",
+									"default": "flatcar-stable-3602.2.1-kube-v1.25.16-gs"
+								}
+
+							}
+						}
+					}
+				},
 				"nodePools": {
 					"type": "object",
 					"title": "Node pools",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -698,6 +698,29 @@
 						}
 					}
 				},
+				"kubectlImage": {
+					"type": "object",
+					"title": "Kubectl image",
+					"description": "Used by cluster-shared library chart to configure coredns in-cluster.",
+					"additionalProperties": false,
+					"properties": {
+						"name": {
+							"type": "string",
+							"title": "Repository",
+							"default": "giantswarm/kubectl"
+						},
+						"registry": {
+							"type": "string",
+							"title": "Registry",
+							"default": "gsoci.azurecr.io"
+						},
+						"tag": {
+							"type": "string",
+							"title": "Tag",
+							"default": "1.25.15"
+						}
+					}
+				},
 				"kubernetesVersion": {
 					"title": "Kubernetes version",
 					"description": "Kubernetes version to deploy. Must match the version available in the image defined at template.",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -616,42 +616,60 @@
 				}
 			}
 		},
-		"apiServer": {
-			"properties": {
-				"certSANs": {
-					"default": [],
-					"description": "Alternative names to encode in the API server's certificate.",
-					"items": {
-						"title": "SAN",
-						"type": "string"
-					},
-					"title": "Subject alternative names (SAN)",
-					"type": "array"
-				},
-				"enableAdmissionPlugins": {
-					"default": "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook",
-					"description": "Comma-separated list of admission plugins to enable.",
-					"title": "Admission plugins",
-					"type": "string"
-				},
-				"featureGates": {
-					"default": "",
-					"description": "Enabled feature gates, as a comma-separated list.",
-					"title": "Feature gates",
-					"type": "string"
-				}
-			},
-			"required": [
-				"enableAdmissionPlugins",
-				"featureGates"
-			],
-			"title": "Kubernetes API server",
-			"type": "object"
-		},
 		"internal": {
 			"type": "object",
 			"additionalProperties": false,
 			"properties": {
+				"apiServer": {
+					"type": "object",
+					"properties": {
+						"enableAdmissionPlugins": {
+							"type": "array",
+							"title": "Admission plugins",
+							"description": "List of admission plugins to be passed to the API server via the --enable-admission-plugins flag.",
+							"items": {
+								"type": "string",
+								"title": "Plugin",
+								"examples": [
+									"DefaultStorageClass",
+									"Priority"
+								],
+								"pattern": "^[A-Za-z0-9]+$"
+							},
+							"default": [
+								"DefaultStorageClass",
+								"DefaultTolerationSeconds",
+								"LimitRanger",
+								"MutatingAdmissionWebhook",
+								"NamespaceLifecycle",
+								"PersistentVolumeClaimResize",
+								"Priority",
+								"ResourceQuota",
+								"ServiceAccount",
+								"ValidatingAdmissionWebhook"
+							]
+						},
+						"certSANs": {
+							"type": "array",
+							"title": "Subject alternative names (SAN)",
+							"description": "Alternative names to encode in the API server's certificate.",
+							"items": {
+								"title": "SAN",
+								"type": "string"
+							},
+							"default": []
+						},
+						"featureGates": {
+							"type": "array",
+							"title": "Feature gates",
+							"description": "API server feature gate activation/deactivation.",
+							"items": {
+								"$ref": "#/$defs/featureGate"
+							},
+							"default": []
+						}
+					}
+				},
 				"ciliumNetworkPolicy": {
 					"type": "object",
 					"title": "CiliumNetworkPolicies",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -15,22 +15,6 @@
 		}
 	},
 	"properties": {
-		"cluster": {
-			"properties": {
-				"kubernetesVersion": {
-					"title": "Kubernetes version",
-					"description": "Kubernetes version to deploy. Must match the version available in the image defined at template.",
-					"type": "string"
-				},
-				"enableEncryptionProvider": {
-					"title": "API server encryption at REST",
-					"description": "Enable encryption at REST feature of API server.",
-					"type": "boolean"
-				}
-			},
-			"title": "Cluster",
-			"type": "object"
-		},
 		"global": {
 			"type": "object",
 			"title": "Properties that are available to all charts and subcharts.",
@@ -675,6 +659,16 @@
 							"default": true
 						}
 					}
+				},
+				"kubernetesVersion": {
+					"title": "Kubernetes version",
+					"description": "Kubernetes version to deploy. Must match the version available in the image defined at template.",
+					"type": "string"
+				},
+				"enableEncryptionProvider": {
+					"title": "API server encryption at REST",
+					"description": "Enable encryption at REST feature of API server.",
+					"type": "boolean"
 				},
 				"teleport": {
 					"type": "object",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -12,6 +12,25 @@
 			},
 			"type": "array",
 			"minItems": 1
+		},
+		"featureGate": {
+			"type": "object",
+			"title": "Feature gate",
+			"additionalProperties": false,
+			"properties": {
+				"enabled": {
+					"type": "boolean",
+					"title": "Enabled"
+				},
+				"name": {
+					"type": "string",
+					"title": "Name",
+					"examples": [
+						"UserNamespacesStatelessPodsSupport"
+					],
+					"pattern": "^[A-Za-z0-9]+$"
+				}
+			}
 		}
 	},
 	"properties": {
@@ -629,21 +648,6 @@
 			"title": "Kubernetes API server",
 			"type": "object"
 		},
-		"controllerManager": {
-			"properties": {
-				"featureGates": {
-					"default": "",
-					"description": "Enabled feature gates, as a comma-separated list.",
-					"title": "Feature gates",
-					"type": "string"
-				}
-			},
-			"required": [
-				"featureGates"
-			],
-			"title": "Kubernetes Controller Manager",
-			"type": "object"
-		},
 		"internal": {
 			"type": "object",
 			"additionalProperties": false,
@@ -657,6 +661,22 @@
 							"title": "Enable CiliumNetworkPolicies",
 							"description": "Installs the network-policies-app (deny all by default) if set to true",
 							"default": true
+						}
+					}
+				},
+				"controllerManager": {
+					"type": "object",
+					"title": "Controller manager",
+					"additionalProperties": false,
+					"properties": {
+						"featureGates": {
+							"type": "array",
+							"title": "Feature gates",
+							"description": "Controller manager feature gate activation/deactivation.",
+							"items": {
+								"$ref": "#/$defs/featureGate"
+							},
+							"default": []
 						}
 					}
 				},

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -1,8 +1,3 @@
-apiServer:
-  enableAdmissionPlugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"
-  featureGates: ""
-  certSANs: []
-
 global:
   connectivity:
     containerRegistries: {}
@@ -65,6 +60,20 @@ global:
     servicePriority: "highest"
 
 internal:
+  apiServer:
+    certSANs: []
+    enableAdmissionPlugins:
+      - DefaultStorageClass
+      - DefaultTolerationSeconds
+      - LimitRanger
+      - MutatingAdmissionWebhook
+      - NamespaceLifecycle
+      - PersistentVolumeClaimResize
+      - Priority
+      - ResourceQuota
+      - ServiceAccount
+      - ValidatingAdmissionWebhook
+    featureGates: []
   ciliumNetworkPolicy:
     enabled: true
   controllerManager:

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -40,6 +40,18 @@ global:
       template: flatcar-stable-3602.2.1-kube-v1.25.16-gs
     oidc: {}
     resourceRatio: 8
+  nodeClasses:
+    default:
+      cloneMode: "linkedClone"
+      diskGiB: 50
+      numCPUs: 6
+      memoryMiB: 16896
+      resourcePool: "*/Resources"
+      template: "flatcar-stable-3602.2.1-kube-v1.25.16-gs"
+      network:
+        devices:
+        - networkName: ""
+          dhcp4: true
   podSecurityStandards:
     enforced: true
   providerSpecific:
@@ -93,15 +105,3 @@ internal:
     registry: gsoci.azurecr.io
     tag: "3.9"
 
-nodeClasses:
-  default:
-    cloneMode: "linkedClone"
-    diskGiB: 50
-    numCPUs: 6
-    memoryMiB: 16896
-    resourcePool: "*/Resources"
-    template: "flatcar-stable-3602.2.1-kube-v1.25.16-gs"
-    network:
-      devices:
-      - networkName: ""
-        dhcp4: true

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -3,10 +3,6 @@ apiServer:
   featureGates: ""
   certSANs: []
 
-cluster:
-  kubernetesVersion: "v1.25.16"
-  enableEncryptionProvider: true
-
 controllerManager:
   featureGates: ""
 
@@ -74,6 +70,8 @@ global:
 internal:
   ciliumNetworkPolicy:
     enabled: true
+  enableEncryptionProvider: true
+  kubernetesVersion: "v1.25.16"
   teleport:
     proxyAddr: teleport.giantswarm.io:443
     version: 14.1.3

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -3,9 +3,6 @@ apiServer:
   featureGates: ""
   certSANs: []
 
-controllerManager:
-  featureGates: ""
-
 global:
   connectivity:
     containerRegistries: {}
@@ -70,6 +67,8 @@ global:
 internal:
   ciliumNetworkPolicy:
     enabled: true
+  controllerManager:
+    featureGates: []
   enableEncryptionProvider: true
   kubernetesVersion: "v1.25.16"
   teleport:

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -79,6 +79,10 @@ internal:
   controllerManager:
     featureGates: []
   enableEncryptionProvider: true
+  kubectlImage:
+    registry: gsoci.azurecr.io
+    name: giantswarm/kubectl
+    tag: 1.23.5
   kubernetesVersion: "v1.25.16"
   teleport:
     proxyAddr: teleport.giantswarm.io:443
@@ -88,11 +92,6 @@ internal:
     name: giantswarm/pause
     registry: gsoci.azurecr.io
     tag: "3.9"
-
-kubectlImage:
-  registry: gsoci.azurecr.io
-  name: giantswarm/kubectl
-  tag: 1.23.5
 
 nodeClasses:
   default:


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/3372


Notes: 

- it's not possible to test this using the e2e CI tests because the [test cluster values](https://github.com/giantswarm/cluster-standup-teardown/blob/main/pkg/clusterbuilder/providers/capv/values/cluster_values.yaml) have not been updated yet (and cannot be updated until the chart refactoring is complete and released). Running the CI tests locally with manually updated values passes though:

```
```

