### PR TITLE
Bump k8s version to 1.26.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove unused values from schema.
 - Update example manifests post-refactor.
 - Improve values schema with definitions to make it more DRY.
+- Bump k8s version from `1.25.16` to `1.26.15`.
 
 ## [0.51.0] - 2024-05-16
 

--- a/helm/cluster-vsphere/README.md
+++ b/helm/cluster-vsphere/README.md
@@ -29,8 +29,8 @@ Properties within the `.internal` top-level object
 | `internal.kubectlImage` | **Kubectl image** - Used by cluster-shared library chart to configure coredns in-cluster.|**Type:** `object`<br/>|
 | `internal.kubectlImage.name` | **Repository**|**Type:** `string`<br/>**Default:** `"giantswarm/kubectl"`|
 | `internal.kubectlImage.registry` | **Registry**|**Type:** `string`<br/>**Default:** `"gsoci.azurecr.io"`|
-| `internal.kubectlImage.tag` | **Tag**|**Type:** `string`<br/>**Default:** `"1.25.15"`|
-| `internal.kubernetesVersion` | **Kubernetes version** - Kubernetes version to deploy. Must match the version available in the image defined at template.|**Type:** `string`<br/>**Default:** `"v1.25.16"`|
+| `internal.kubectlImage.tag` | **Tag**|**Type:** `string`<br/>**Default:** `"1.26.15"`|
+| `internal.kubernetesVersion` | **Kubernetes version** - Kubernetes version to deploy. Must match the version available in the image defined at template.|**Type:** `string`<br/>**Default:** `"v1.26.15"`|
 | `internal.sandboxContainerImage` | **Sandbox Container image**|**Type:** `object`<br/>|
 | `internal.sandboxContainerImage.name` | **Repository**|**Type:** `string`<br/>**Default:** `"giantswarm/pause"`|
 | `internal.sandboxContainerImage.registry` | **Registry**|**Type:** `string`<br/>**Default:** `"gsoci.azurecr.io"`|
@@ -100,7 +100,7 @@ Properties within the `.global.controlPlane` object
 | `global.controlPlane.machineTemplate.network.devices[*].networkName` | **Segment name** - Segment name to attach nodes to. Must already exist.|**Type:** `string`<br/>|
 | `global.controlPlane.machineTemplate.numCPUs` | **Number of CPUs**|**Type:** `integer`<br/>**Example:** `6`<br/>|
 | `global.controlPlane.machineTemplate.resourcePool` | **VSphere resource pool name**|**Type:** `string`<br/>**Default:** `"*/Resources"`|
-| `global.controlPlane.machineTemplate.template` | **VM template**|**Type:** `string`<br/>**Default:** `"flatcar-stable-3602.2.1-kube-v1.25.16-gs"`|
+| `global.controlPlane.machineTemplate.template` | **VM template**|**Type:** `string`<br/>**Default:** `"flatcar-stable-3815.2.0-kube-v1.26.15-gs"`|
 | `global.controlPlane.oidc` | **OIDC authentication**|**Type:** `object`<br/>|
 | `global.controlPlane.oidc.caFile` | **Certificate authority file** - Path to identity provider's CA certificate in PEM format.|**Type:** `string`<br/>|
 | `global.controlPlane.oidc.clientId` | **Client ID** - OIDC client identifier to identify with.|**Type:** `string`<br/>|
@@ -175,7 +175,7 @@ Properties within the `.global.nodeClasses` object
 | `global.nodeClasses.default.network.devices[*].networkName` | **Segment name** - Segment name to attach nodes to. Must already exist.|**Type:** `string`<br/>|
 | `global.nodeClasses.default.numCPUs` | **Number of CPUs**|**Type:** `integer`<br/>**Example:** `6`<br/>|
 | `global.nodeClasses.default.resourcePool` | **VSphere resource pool name**|**Type:** `string`<br/>**Default:** `"*/Resources"`|
-| `global.nodeClasses.default.template` | **VM template**|**Type:** `string`<br/>**Default:** `"flatcar-stable-3602.2.1-kube-v1.25.16-gs"`|
+| `global.nodeClasses.default.template` | **VM template**|**Type:** `string`<br/>**Default:** `"flatcar-stable-3815.2.0-kube-v1.26.15-gs"`|
 
 ### Other
 

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -258,7 +258,7 @@ ignition:
             RemainAfterExit=yes
             Environment=OUTPUT=/run/metadata/coreos
             ExecStart=/usr/bin/mkdir --parent /run/metadata
-            ExecStart=/usr/bin/bash -cv 'echo "COREOS_CUSTOM_HOSTNAME=$(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.metadata" | base64 -d | grep local-hostname | awk {\'print $2\'} | tr -d \'"\')" > ${OUTPUT}'
+            ExecStart=/usr/bin/bash -cv 'echo "COREOS_CUSTOM_HOSTNAME=$("$(find /usr/bin /usr/share/oem -name vmtoolsd -type f -executable 2>/dev/null | head -n 1)" --cmd "info-get guestinfo.metadata" | base64 -d | grep local-hostname | awk {\'print $2\'} | tr -d \'"\')" > $${OUTPUT}'
         - name: set-hostname.service
           enabled: true
           contents: |

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -103,7 +103,7 @@
         "template": {
             "type": "string",
             "title": "VM template",
-            "default": "flatcar-stable-3602.2.1-kube-v1.25.16-gs"
+            "default": "flatcar-stable-3815.2.0-kube-v1.26.15-gs"
         }
     },
     "type": "object",
@@ -784,7 +784,7 @@
                         "tag": {
                             "type": "string",
                             "title": "Tag",
-                            "default": "1.25.15"
+                            "default": "1.26.15"
                         }
                     }
                 },
@@ -792,7 +792,7 @@
                     "type": "string",
                     "title": "Kubernetes version",
                     "description": "Kubernetes version to deploy. Must match the version available in the image defined at template.",
-                    "default": "v1.25.16"
+                    "default": "v1.26.15"
                 },
                 "sandboxContainerImage": {
                     "type": "object",

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -33,7 +33,7 @@ global:
           networkName: ""
       numCPUs: 4
       resourcePool: '*/Resources'
-      template: flatcar-stable-3602.2.1-kube-v1.25.16-gs
+      template: flatcar-stable-3815.2.0-kube-v1.26.15-gs
     oidc: {}
     resourceRatio: 8
   metadata:
@@ -48,7 +48,7 @@ global:
           networkName: ""
       numCPUs: 6
       resourcePool: '*/Resources'
-      template: flatcar-stable-3602.2.1-kube-v1.25.16-gs
+      template: flatcar-stable-3815.2.0-kube-v1.26.15-gs
   nodePools:
     worker:
       class: default
@@ -80,8 +80,8 @@ internal:
   kubectlImage:
     name: giantswarm/kubectl
     registry: gsoci.azurecr.io
-    tag: 1.25.15
-  kubernetesVersion: v1.25.16
+    tag: 1.26.15
+  kubernetesVersion: v1.26.15
   sandboxContainerImage:
     name: giantswarm/pause
     registry: gsoci.azurecr.io


### PR DESCRIPTION
This PR sets default k8s version `1.26.15`.

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
