### PR TITLE
remove kube-vip values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove kube-vip values to rely on the defaults of `cloud-provider-vsphere-app`.
+
 ## [0.52.0] - 2024-05-23
 
 ### Changed

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -56,12 +56,3 @@ spec:
         enforced: {{ .Values.global.podSecurityStandards.enforced }}
     kube-vip-cloud-provider:
       cidrGlobal: '{{ join "," .Values.global.connectivity.network.loadBalancers.cidrBlocks }}'
-      image:
-        repository: docker.io/giantswarm/kube-vip-cloud-provider
-        tag: v0.0.4
-    kube-vip:
-      env:
-        vip_interface: "ens192"
-      image:
-        repository: docker.io/giantswarm/kube-vip
-        tag: v0.6.3


### PR DESCRIPTION
This pr removes the kube-vip values set in the cloud provider's HelmRelease.

Towards `1.` in https://github.com/giantswarm/roadmap/issues/3467

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
