### PR TITLE
Fix IPAM's pre-install hook for k8s 1.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Refer the API group (`ipam.cluster.x-k8s.io`) of `cluster-api-ipam-provider-in-cluster` for `ipaddresses` CRs to not use the built-in Kubernetes group (`networking.k8s.io/v1alpha1`).
+
 ## [0.53.0] - 2024-06-06
 
 ### Changed

--- a/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
+++ b/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
@@ -89,7 +89,7 @@ spec:
               new_ip=""
               while [ -z "${new_ip}" ] ; do
                 echo "waiting for a free IP address.."
-                new_ip=$(kubectl get ipaddress --ignore-not-found -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }} -o 'jsonpath={.spec.address}')
+                new_ip=$(kubectl get ipaddresses.ipam.cluster.x-k8s.io --ignore-not-found -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }} -o 'jsonpath={.spec.address}')
                 sleep 2
               done
               echo "Got the IP: ${new_ip}"
@@ -123,7 +123,7 @@ spec:
               new_ip=""
               while [ -z "${new_ip}" ] ; do
                 echo "waiting for a free IP address.."
-                new_ip=$(kubectl get ipaddress --ignore-not-found -n {{ $.Release.Namespace }} {{ include "lbClaimName" $ }} -o 'jsonpath={.spec.address}')
+                new_ip=$(kubectl get ipaddresses.ipam.cluster.x-k8s.io --ignore-not-found -n {{ $.Release.Namespace }} {{ include "lbClaimName" $ }} -o 'jsonpath={.spec.address}')
                 sleep 2
               done
               echo "Got the IP: ${new_ip}"
@@ -145,7 +145,7 @@ spec:
               set -o pipefail
               set -o nounset
               echo "New IPs have been assigned, upausing the Cluster '{{ include "resource.default.name" $ }}' resource.."
-              kubectl get ipaddress -n {{ $.Release.Namespace }}
+              kubectl get ipaddresses.ipam.cluster.x-k8s.io -n {{ $.Release.Namespace }}
               kubectl patch cluster -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }} --type=merge -p '{"spec":{"paused":false}}'
 ---
 {{- end }}


### PR DESCRIPTION
The pre-install hook for IPAM fails with this error
```
❯ k logs t-2lyjs48jftdkqcis2p-update-values-hook-tpkzm -c get-ip-for-control-plane
waiting for a free IP address..
Error from server (Forbidden): ipaddresses.networking.k8s.io "t-2lyjs48jftdkqcis2p" is forbidden: User "system:serviceaccount:org-t-f6e19e51e741rxmeon:t-2lyjs48jftdkqcis2p-update-values-hook" cannot get resource "ipaddresses" in API group "networking.k8s.io" at the cluster scope
```

because k8s 1.27 introduced a new API group for networking: `networking.k8s.io/v1alpha1`

This PR adds the API group (`ipam.cluster.x-k8s.io`) of `cluster-api-ipam-provider-in-cluster` for `ipaddresses` CRs explicitly in the pre-install hook.