### PR TITLE
consume cloud-provider-vsphere-app #98

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update vSphere CSI to `3.2.0` for Kubernetes 1.27 compatibility.
-- Update vSphere CPI to `1.27.0` for Kubernetes 1.27 compatibility.
-- Update `kube-vip` to `0.8.0`.
-- Update `kube-vip-cloud-provider` to `0.0.5`.
+- Bump `cloud-provider-vsphere` to `1.7.0` for **Kubernetes 1.27** compatibility.
+  - Update **vSphere CSI** to `3.2.0`.
+  - Update **vSphere CPI** to `1.27.0`.
+  - Update **kube-vip** to `0.8.0`.
+  - Update **kube-vip-cloud-provider** to `0.0.5`.
 
 ## [0.53.1] - 2024-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update vSphere CSI to `3.2.0` for Kubernetes 1.27 compatibility.
+- Update vSphere CPI to `1.27.0` for Kubernetes 1.27 compatibility.
+- Update `kube-vip` to `0.8.0`.
+- Update `kube-vip-cloud-provider` to `0.0.5`.
+
 ## [0.53.1] - 2024-06-09
 
 ### Fixed

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -19,10 +19,10 @@ spec:
       chart: cloud-provider-vsphere
       # used by renovate
       # repo: giantswarm/cloud-provider-vsphere-app
-      version: 1.6.0
+      version: 1.6.0-e6b2948980dc27e2feb4cc9d991878329a4442a8
       sourceRef:
         kind: HelmRepository
-        name: {{ include "resource.default.name" $ }}-default
+        name: {{ include "resource.default.name" $ }}-default-test
   dependsOn:
     - name: {{ include "resource.default.name" $ }}-cilium
       namespace: {{ $.Release.Namespace }}

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
       chart: cloud-provider-vsphere
       # used by renovate
       # repo: giantswarm/cloud-provider-vsphere-app
-      version: 1.6.0-e6b2948980dc27e2feb4cc9d991878329a4442a8
+      version: 1.6.0-2baca23c7e05a5c3c5f39ea00a128e92fbe32507
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default-test

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
       chart: cloud-provider-vsphere
       # used by renovate
       # repo: giantswarm/cloud-provider-vsphere-app
-      version: 1.6.0-2baca23c7e05a5c3c5f39ea00a128e92fbe32507
+      version: 1.6.0-fd9caa47096197fbb9dc2731a2ea63d14269d9b4
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default-test

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -19,10 +19,10 @@ spec:
       chart: cloud-provider-vsphere
       # used by renovate
       # repo: giantswarm/cloud-provider-vsphere-app
-      version: 1.6.0-a2deb56218fe94d86f9a2459722bf15dd5260c3b
+      version: 1.7.0
       sourceRef:
         kind: HelmRepository
-        name: {{ include "resource.default.name" $ }}-default-test
+        name: {{ include "resource.default.name" $ }}-default
   dependsOn:
     - name: {{ include "resource.default.name" $ }}-cilium
       namespace: {{ $.Release.Namespace }}

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
       chart: cloud-provider-vsphere
       # used by renovate
       # repo: giantswarm/cloud-provider-vsphere-app
-      version: 1.6.0-fd9caa47096197fbb9dc2731a2ea63d14269d9b4
+      version: 1.6.0-364610f949fa9398b7d917c7ce10b1511f9ae2e1
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default-test

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
       chart: cloud-provider-vsphere
       # used by renovate
       # repo: giantswarm/cloud-provider-vsphere-app
-      version: 1.6.0-364610f949fa9398b7d917c7ce10b1511f9ae2e1
+      version: 1.6.0-a2deb56218fe94d86f9a2459722bf15dd5260c3b
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default-test


### PR DESCRIPTION
This pr consumes the updated version of the `cloud-provider-vsphere` app.
https://github.com/giantswarm/cloud-provider-vsphere-app/pull/98

- Update vSphere CSI to `3.2.0` for Kubernetes 1.27 compatibility.
- Update vSphere CPI to `1.27.0` for Kubernetes 1.27 compatibility.
- Update `kube-vip` to `0.8.0`.
- Update `kube-vip-cloud-provider` to `0.0.5`.

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
