### PR TITLE
Correct default values for networks in values schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Correct default values for `network`s in values schema.
+
 ## [0.55.0] - 2024-06-25
 
 ### Changed

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -418,13 +418,7 @@
                                 },
                                 "network": {
                                     "$ref": "#/$defs/network",
-                                    "description": "Control plane node network configuration.",
-                                    "default": [
-                                        {
-                                            "dhcp4": true,
-                                            "networkName": ""
-                                        }
-                                    ]
+                                    "description": "Control plane node network configuration."
                                 },
                                 "numCPUs": {
                                     "$ref": "#/$defs/numCPUs",
@@ -571,13 +565,7 @@
                                 },
                                 "network": {
                                     "$ref": "#/$defs/network",
-                                    "description": "Worker node network configuration.",
-                                    "default": [
-                                        {
-                                            "dhcp4": true,
-                                            "networkName": ""
-                                        }
-                                    ]
+                                    "description": "Worker node network configuration."
                                 },
                                 "numCPUs": {
                                     "$ref": "#/$defs/numCPUs",

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -33,8 +33,9 @@ global:
       cloneMode: linkedClone
       memoryMiB: 8192
       network:
-        - dhcp4: true
-          networkName: ""
+        devices:
+          - dhcp4: true
+            networkName: ""
       numCPUs: 4
       resourcePool: '*/Resources'
       template: flatcar-stable-3815.2.2-kube-v1.27.14-gs
@@ -48,8 +49,9 @@ global:
       cloneMode: linkedClone
       memoryMiB: 16896
       network:
-        - dhcp4: true
-          networkName: ""
+        devices:
+          - dhcp4: true
+            networkName: ""
       numCPUs: 6
       resourcePool: '*/Resources'
       template: flatcar-stable-3815.2.2-kube-v1.27.14-gs


### PR DESCRIPTION
Simon did a stupid when refactoring the chart. Luckily Helm seems to ignore the issue and cluster charts in use were unaffected.

The defaults can be removed as the definition of `network` already contains the correct defaults.

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
