### PR TITLE
Remove nodeClasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+### **Breaking change**.
+
+<details>
+<summary>How to migrate values</summary>
+
+Using `yq`, migrate to the new values layout with the following command:
+
+```bash
+yq eval --inplace 'with(select(.global.nodePools != null);  .global.nodePools |= to_entries | .global.nodePools |= map(.value + {"name": .key})) |
+    with(select(.global.nodeClasses != null);               .global.nodeClasses as $classes | with(.global.nodePools[]; . *= $classes[.class])) |
+    
+    del(.global.nodePools[].class) |
+    del(.global.nodeClasses)' values.yaml
+```
+
+</details>
+
+### Changed
+
+- Converted Helm values property `.Values.global.nodePools` from a map to an array, moving the map's name to the key `name`.
+- Move Helm values from each `.global.nodeClasses.$<class>` to any nodePool which references that class.
+- Deleted Helm values property `.global.nodeClasses`.
+
 ### Fixed
 
 - Correct default values for `network`s in values schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Using `yq`, migrate to the new values layout with the following command:
 
 ```bash
-yq eval --inplace 'with(select(.global.nodePools != null);  .global.nodePools |= to_entries | .global.nodePools |= map(.value + {"name": .key})) |
-    with(select(.global.nodeClasses != null);               .global.nodeClasses as $classes | with(.global.nodePools[]; . *= $classes[.class])) |
-    
+yq eval --inplace 'with(select(.global.nodeClasses != null);    .global.nodeClasses as $classes | with(.global.nodePools[]; . *= $classes[.class])) |
+
     del(.global.nodePools[].class) |
     del(.global.nodeClasses)' values.yaml
 ```
@@ -28,7 +27,6 @@ yq eval --inplace 'with(select(.global.nodePools != null);  .global.nodePools |=
 
 ### Changed
 
-- Converted Helm values property `.Values.global.nodePools` from a map to an array, moving the map's name to the key `name`.
 - Move Helm values from each `.global.nodeClasses.$<class>` to any nodePool which references that class.
 - Deleted Helm values property `.global.nodeClasses`.
 

--- a/helm/cluster-vsphere/README.md
+++ b/helm/cluster-vsphere/README.md
@@ -95,7 +95,7 @@ Properties within the `.global.controlPlane` object
 | `global.controlPlane.image` | **Node container image**|**Type:** `object`<br/>|
 | `global.controlPlane.image.repository` | **Repository**|**Type:** `string`<br/>**Default:** `"gsoci.azurecr.io/giantswarm"`|
 | `global.controlPlane.machineTemplate` | **Template to define control plane nodes**|**Type:** `object`<br/>|
-| `global.controlPlane.machineTemplate.cloneMode` | **Template clone mode** - VM template cloning method.|**Type:** `string`<br/>**Default:** `"linkedClone"`|
+| `global.controlPlane.machineTemplate.cloneMode` | **VM template clone mode**|**Type:** `string`<br/>**Default:** `"linkedClone"`|
 | `global.controlPlane.machineTemplate.diskGiB` | **Disk size**|**Type:** `integer`<br/>**Example:** `30`<br/>|
 | `global.controlPlane.machineTemplate.memoryMiB` | **Memory size**|**Type:** `integer`<br/>**Example:** `8192`<br/>|
 | `global.controlPlane.machineTemplate.network` | **Network configuration**|**Type:** `object`<br/>|
@@ -136,11 +136,19 @@ Groups of worker nodes with identical configuration.
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `global.nodePools.PATTERN` |**None**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]{3,10}$`<br/>|
-| `global.nodePools.PATTERN.class` | **Node class** - A valid node class name.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]{3,10}$`<br/>**Value pattern:** `^[a-z0-9-]+$`<br/>|
-| `global.nodePools.PATTERN.replicas` | **Number of nodes**|**Type:** `integer`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]{3,10}$`<br/>**Default:** `1`|
-| `global.nodePools.worker` | **Default nodePool**|**Type:** `object`<br/>|
-| `global.nodePools.worker.class` | **Node class** - A valid node class name.|**Type:** `string`<br/>**Default:** `"default"`|
-| `global.nodePools.worker.replicas` | **Number of nodes**|**Type:** `integer`<br/>**Default:** `2`|
+| `global.nodePools.default` | **Default nodePool**|**Type:** `object`<br/>|
+| `global.nodePools.default.cloneMode` | **VM template clone mode**|**Type:** `string`<br/>**Default:** `"linkedClone"`|
+| `global.nodePools.default.diskGiB` | **Disk size**|**Type:** `integer`<br/>**Example:** `30`<br/>|
+| `global.nodePools.default.memoryMiB` | **Memory size**|**Type:** `integer`<br/>**Example:** `8192`<br/>|
+| `global.nodePools.default.network` | **Network configuration**|**Type:** `object`<br/>|
+| `global.nodePools.default.network.devices` | **Network devices** - Network interface configuration for VMs.|**Type:** `array`<br/>**Default:** `[{"dhcp4":true,"networkName":""}]`|
+| `global.nodePools.default.network.devices[*]` | **Devices**|**Type:** `object`<br/>|
+| `global.nodePools.default.network.devices[*].dhcp4` | **IPv4 DHCP** - Is DHCP enabled on this segment.|**Type:** `boolean`<br/>|
+| `global.nodePools.default.network.devices[*].networkName` | **Segment name** - Segment name to attach nodes to. Must already exist.|**Type:** `string`<br/>|
+| `global.nodePools.default.numCPUs` | **Number of CPUs**|**Type:** `integer`<br/>**Example:** `6`<br/>|
+| `global.nodePools.default.replicas` | **Number of nodes**|**Type:** `integer`<br/>**Default:** `2`|
+| `global.nodePools.default.resourcePool` | **VSphere resource pool name**|**Type:** `string`<br/>**Default:** `"*/Resources"`|
+| `global.nodePools.default.template` | **VM template**|**Type:** `string`<br/>**Default:** `"flatcar-stable-3815.2.2-kube-v1.27.14-gs"`|
 
 ### Pod Security Standards
 Properties within the `.global.podSecurityStandards` object
@@ -163,24 +171,6 @@ Properties within the `.global.providerSpecific` object
 | `global.providerSpecific.vcenter.thumbprint` | **Thumbprint** - TLS certificate signature of the VSphere API.|**Type:** `string`<br/>|
 | `global.providerSpecific.vcenter.username` | **Username** - Username for the VSphere API.|**Type:** `string`<br/>|
 | `global.providerSpecific.vcenter.zone` | **Zone** - Category name in VSphere for topology.kubernetes.io/zone labels.|**Type:** `string`<br/>|
-
-### Template to define worker nodes
-Properties within the `.global.nodeClasses` object
-
-| **Property** | **Description** | **More Details** |
-| :----------- | :-------------- | :--------------- |
-| `global.nodeClasses.default` | **Default node class configuration**|**Type:** `object`<br/>|
-| `global.nodeClasses.default.cloneMode` | **Template clone mode** - VM template cloning method.|**Type:** `string`<br/>**Default:** `"linkedClone"`|
-| `global.nodeClasses.default.diskGiB` | **Disk size**|**Type:** `integer`<br/>**Example:** `30`<br/>|
-| `global.nodeClasses.default.memoryMiB` | **Memory size**|**Type:** `integer`<br/>**Example:** `8192`<br/>|
-| `global.nodeClasses.default.network` | **Network configuration**|**Type:** `object`<br/>|
-| `global.nodeClasses.default.network.devices` | **Network devices** - Network interface configuration for VMs.|**Type:** `array`<br/>**Default:** `[{"dhcp4":true,"networkName":""}]`|
-| `global.nodeClasses.default.network.devices[*]` | **Devices**|**Type:** `object`<br/>|
-| `global.nodeClasses.default.network.devices[*].dhcp4` | **IPv4 DHCP** - Is DHCP enabled on this segment.|**Type:** `boolean`<br/>|
-| `global.nodeClasses.default.network.devices[*].networkName` | **Segment name** - Segment name to attach nodes to. Must already exist.|**Type:** `string`<br/>|
-| `global.nodeClasses.default.numCPUs` | **Number of CPUs**|**Type:** `integer`<br/>**Example:** `6`<br/>|
-| `global.nodeClasses.default.resourcePool` | **VSphere resource pool name**|**Type:** `string`<br/>**Default:** `"*/Resources"`|
-| `global.nodeClasses.default.template` | **VM template**|**Type:** `string`<br/>**Default:** `"flatcar-stable-3815.2.2-kube-v1.27.14-gs"`|
 
 ### Other
 

--- a/helm/cluster-vsphere/ci/ci-values.yaml
+++ b/helm/cluster-vsphere/ci/ci-values.yaml
@@ -25,8 +25,16 @@ global:
             dhcp4: true
   nodePools:
     worker:
-      class: "default"
       replicas: 2
+      cloneMode: "linkedClone"
+      diskGiB: 25
+      numCPUs: 2
+      memoryMiB: 8192
+      resourcePool: "grasshopper"
+      network:
+        devices:
+          - networkName: 'grasshopper-capv'
+            dhcp4: true
   providerSpecific:
     vcenter:
       server: "https://foo.example.com"
@@ -38,16 +46,5 @@ global:
       thumbprint: "F7:CF:F9:E5:99:39:FF:C1:D7:14:F1:3F:8A:42:21:95:3B:A1:6E:16"
       region: "k8s-region"
       zone: "k8s-zone"
-  nodeClasses:
-    default:
-      cloneMode: "linkedClone"
-      diskGiB: 25
-      numCPUs: 2
-      memoryMiB: 8192
-      resourcePool: "grasshopper"
-      network:
-        devices:
-          - networkName: 'grasshopper-capv'
-            dhcp4: true
 internal:
   enableEncryptionProvider: false

--- a/helm/cluster-vsphere/ci/ci-values.yaml
+++ b/helm/cluster-vsphere/ci/ci-values.yaml
@@ -24,7 +24,7 @@ global:
           - networkName: 'grasshopper-capv'
             dhcp4: true
   nodePools:
-    worker:
+    default:
       replicas: 2
       cloneMode: "linkedClone"
       diskGiB: 25

--- a/helm/cluster-vsphere/ci/test-multiple-mirrors-with-auth-and-local-caching.yaml
+++ b/helm/cluster-vsphere/ci/test-multiple-mirrors-with-auth-and-local-caching.yaml
@@ -40,7 +40,7 @@ global:
           - networkName: 'grasshopper-capv'
             dhcp4: true
   nodePools:
-    worker:
+    default:
       replicas: 2
       cloneMode: "linkedClone"
       diskGiB: 25

--- a/helm/cluster-vsphere/ci/test-multiple-mirrors-with-auth-and-local-caching.yaml
+++ b/helm/cluster-vsphere/ci/test-multiple-mirrors-with-auth-and-local-caching.yaml
@@ -41,8 +41,16 @@ global:
             dhcp4: true
   nodePools:
     worker:
-      class: "default"
       replicas: 2
+      cloneMode: "linkedClone"
+      diskGiB: 25
+      numCPUs: 2
+      memoryMiB: 8192
+      resourcePool: "grasshopper"
+      network:
+        devices:
+          - networkName: 'grasshopper-capv'
+            dhcp4: true
   providerSpecific:
     vcenter:
       server: "https://foo.example.com"
@@ -54,16 +62,5 @@ global:
       thumbprint: "F7:CF:F9:E5:99:39:FF:C1:D7:14:F1:3F:8A:42:21:95:3B:A1:6E:16"
       region: "k8s-region"
       zone: "k8s-zone"
-  nodeClasses:
-    default:
-      cloneMode: "linkedClone"
-      diskGiB: 25
-      numCPUs: 2
-      memoryMiB: 8192
-      resourcePool: "grasshopper"
-      network:
-        devices:
-          - networkName: 'grasshopper-capv'
-            dhcp4: true
 internal:
   enableEncryptionProvider: false

--- a/helm/cluster-vsphere/ci/test-wc-values.yaml
+++ b/helm/cluster-vsphere/ci/test-wc-values.yaml
@@ -25,8 +25,16 @@ global:
             dhcp4: true
   nodePools:
     worker:
-      class: "default"
       replicas: 2
+      cloneMode: "linkedClone"
+      diskGiB: 25
+      numCPUs: 2
+      memoryMiB: 8192
+      resourcePool: "grasshopper"
+      network:
+        devices:
+          - networkName: 'grasshopper-capv'
+            dhcp4: true
   providerSpecific:
     vcenter:
       server: "https://foo.example.com"
@@ -38,16 +46,5 @@ global:
       thumbprint: "F7:CF:F9:E5:99:39:FF:C1:D7:14:F1:3F:8A:42:21:95:3B:A1:6E:16"
       region: "k8s-region"
       zone: "k8s-zone"
-  nodeClasses:
-    default:
-      cloneMode: "linkedClone"
-      diskGiB: 25
-      numCPUs: 2
-      memoryMiB: 8192
-      resourcePool: "grasshopper"
-      network:
-        devices:
-          - networkName: 'grasshopper-capv'
-            dhcp4: true
 internal:
   enableEncryptionProvider: false

--- a/helm/cluster-vsphere/ci/test-wc-values.yaml
+++ b/helm/cluster-vsphere/ci/test-wc-values.yaml
@@ -24,7 +24,7 @@ global:
           - networkName: 'grasshopper-capv'
             dhcp4: true
   nodePools:
-    worker:
+    default:
       replicas: 2
       cloneMode: "linkedClone"
       diskGiB: 25

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -53,7 +53,7 @@ create VSphereMachineTemplates.
 {{- $nodeMap := dict -}}
 {{- $_ := set $nodeMap "control-plane" .Values.global.controlPlane.machineTemplate -}}
 {{- range $index, $pool := .Values.global.nodePools -}}
-  {{- $_ := set $nodeMap $pool.name $pool -}}
+  {{- $_ := set $nodeMap $index $pool -}}
 {{- end -}}
 {{ toYaml $nodeMap }}
 {{- end }}
@@ -66,7 +66,7 @@ MachineDeployments.
 {{ define "createMapOfWorkerPoolSpecs" -}}
 {{- $nodeMap := dict -}}
 {{- range $index, $pool := .Values.global.nodePools -}}
-  {{- $_ := set $nodeMap $pool.name $pool -}}
+  {{- $_ := set $nodeMap $index $pool -}}
 {{- end -}}
 {{ toYaml $nodeMap }}
 {{- end }}

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -59,6 +59,19 @@ create VSphereMachineTemplates.
 {{- end }}
 
 {{/*
+Takes an array of maps containing worker nodePools and adds each map to a new
+map. Results in a map of node specs which can be iterated over to create
+MachineDeployments.
+*/}}
+{{ define "createMapOfWorkerPoolSpecs" -}}
+{{- $nodeMap := dict -}}
+{{- range $index, $pool := .Values.global.nodePools -}}
+  {{- $_ := set $nodeMap $pool.name $pool -}}
+{{- end -}}
+{{ toYaml $nodeMap }}
+{{- end }}
+
+{{/*
 Common labels without kubernetes version
 https://github.com/giantswarm/giantswarm/issues/22441
 */}}

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -51,7 +51,7 @@ create VSphereMachineTemplates.
 */}}
 {{ define "createMapOfClusterNodeSpecs" }}
 {{- $nodeMap := dict -}}
-{{- $_ := set $nodeMap "control-plane" .Values.global.controlPlane.spec -}}
+{{- $_ := set $nodeMap "control-plane" .Values.global.controlPlane.machineTemplate -}}
 {{- range $index, $pool := .Values.global.nodePools -}}
   {{- $_ := set $nodeMap $pool.name $pool -}}
 {{- end -}}

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -28,7 +28,7 @@ datacenter: {{ $.global.providerSpecific.vcenter.datacenter }}
 datastore: {{ $.global.providerSpecific.vcenter.datastore }}
 server: {{ $.global.providerSpecific.vcenter.server }}
 thumbprint: {{ $.global.providerSpecific.vcenter.thumbprint }}
-{{ toYaml .currentClass }}
+{{ toYaml .currentPool }}
 {{- end -}}
 
 {{- define "mtRevision" -}}

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -31,7 +31,7 @@ thumbprint: {{ $.global.providerSpecific.vcenter.thumbprint }}
 {{ toYaml .currentPool }}
 {{- end -}}
 
-{{*/
+{{/*
 mtRevision takes a dict which includes the node's spec and computes a hash value
 from it. This hash value is appended to the name of immutable resources to facilitate
 node replacement when the node spec is changed.

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -72,6 +72,24 @@ MachineDeployments.
 {{- end }}
 
 {{/*
+Takes kubeadm configuration as an input and computes a hash value from it.
+*/}}
+{{- define "kubeadmConfigTemplateRevision" -}}
+{{- $inputs := (dict
+  "data" (include "kubeadmConfigTemplateSpec" .) ) }}
+{{- mustToJson $inputs | toString | quote | sha1sum | trunc 8 }}
+{{- end -}}
+
+{{/*
+Creates a hash value for the control plane via the mtRevision function. Used
+to create a unique name for resources based on their specification.
+*/}}
+{{- define "mtRevisionByControlPlane" -}}
+{{- $outerScope := . }}
+{{- include "mtRevision" (merge (dict "currentClass" .Values.global.controlPlane.machineTemplate) $outerScope.Values) }}
+{{- end -}}
+
+{{/*
 Common labels without kubernetes version
 https://github.com/giantswarm/giantswarm/issues/22441
 */}}
@@ -176,19 +194,6 @@ preKubeadmCommands:
   {{- end }}
 postKubeadmCommands:
 - usermod -aG root nobody # required for node-exporter to access the host's filesystem
-{{- end -}}
-
-
-{{- define "kubeadmConfigTemplateRevision" -}}
-{{- $inputs := (dict
-  "data" (include "kubeadmConfigTemplateSpec" .) ) }}
-{{- mustToJson $inputs | toString | quote | sha1sum | trunc 8 }}
-{{- end -}}
-
-
-{{- define "mtRevisionByControlPlane" -}}
-{{- $outerScope := . }}
-{{- include "mtRevision" (merge (dict "currentClass" .Values.global.controlPlane.machineTemplate) $outerScope.Values) }}
 {{- end -}}
 
 {{/*

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -51,7 +51,7 @@ create VSphereMachineTemplates.
 */}}
 {{ define "createMapOfClusterNodeSpecs" }}
 {{- $nodeMap := dict -}}
-{{- $_ := set $nodeMap "control-plane" .Values.global.controlPlane -}}
+{{- $_ := set $nodeMap "control-plane" .Values.global.controlPlane.spec -}}
 {{- range $index, $pool := .Values.global.nodePools -}}
   {{- $_ := set $nodeMap $pool.name $pool -}}
 {{- end -}}

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -28,7 +28,7 @@ datacenter: {{ $.global.providerSpecific.vcenter.datacenter }}
 datastore: {{ $.global.providerSpecific.vcenter.datastore }}
 server: {{ $.global.providerSpecific.vcenter.server }}
 thumbprint: {{ $.global.providerSpecific.vcenter.thumbprint }}
-{{ toYaml .currentPool }}
+{{ unset .currentPool "replicas" | toYaml }}
 {{- end -}}
 
 {{/*

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -185,14 +185,6 @@ postKubeadmCommands:
 {{- mustToJson $inputs | toString | quote | sha1sum | trunc 8 }}
 {{- end -}}
 
-{{- define "mtRevisionByClass" -}}
-{{- $outerScope := . }}
-{{- range $name, $value := .currentValues.global.nodeClasses }}
-{{- if eq $name $outerScope.class }}
-{{- include "mtRevision" (merge (dict "currentClass" $value) $outerScope.currentValues) }}
-{{- end }}
-{{- end }}
-{{- end -}}
 
 {{- define "mtRevisionByControlPlane" -}}
 {{- $outerScope := . }}

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -49,7 +49,7 @@ takes a array of maps containing nodePools and adds each nodePool's map to
 the new map. Reults in a map of node specs which can be iterated over to 
 create VSphereMachineTemplates.
 */}}
-{{ define "createMapOfNodeSpecs" }}
+{{ define "createMapOfClusterNodeSpecs" }}
 {{- $nodeMap := dict -}}
 {{- $_ := set $nodeMap "control-plane" .Values.global.controlPlane -}}
 {{- range $index, $pool := .Values.global.nodePools -}}

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -39,6 +39,21 @@ thumbprint: {{ $.global.providerSpecific.vcenter.thumbprint }}
 {{- end -}}
 
 {{/*
+First takes a map of the controlPlane's spec and adds it to a new map, then
+takes a array of maps containing nodePools and adds each nodePool's map to
+the new map. Reults in a map of node specs which can be iterated over to 
+create VSphereMachineTemplates.
+*/}}
+{{ define "createMapOfNodeSpecs" }}
+{{- $nodeMap := dict -}}
+{{- $_ := set $nodeMap "control-plane" .Values.global.controlPlane -}}
+{{- range $index, $pool := .Values.global.nodePools -}}
+  {{- $_ := set $nodeMap $pool.name $pool -}}
+{{- end -}}
+{{ toYaml $nodeMap }}
+{{- end }}
+
+{{/*
 Common labels without kubernetes version
 https://github.com/giantswarm/giantswarm/issues/22441
 */}}

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -31,6 +31,11 @@ thumbprint: {{ $.global.providerSpecific.vcenter.thumbprint }}
 {{ toYaml .currentPool }}
 {{- end -}}
 
+{{*/
+mtRevision takes a dict which includes the node's spec and computes a hash value
+from it. This hash value is appended to the name of immutable resources to facilitate
+node replacement when the node spec is changed.
+*/}}
 {{- define "mtRevision" -}}
 {{- $inputs := (dict
   "spec" (include "mtSpec" .)

--- a/helm/cluster-vsphere/templates/_helpers.tpl
+++ b/helm/cluster-vsphere/templates/_helpers.tpl
@@ -86,7 +86,7 @@ to create a unique name for resources based on their specification.
 */}}
 {{- define "mtRevisionByControlPlane" -}}
 {{- $outerScope := . }}
-{{- include "mtRevision" (merge (dict "currentClass" .Values.global.controlPlane.machineTemplate) $outerScope.Values) }}
+{{- include "mtRevision" (merge (dict "currentPool" .Values.global.controlPlane.machineTemplate) $outerScope.Values) }}
 {{- end -}}
 
 {{/*

--- a/helm/cluster-vsphere/templates/machinedeployment.yaml
+++ b/helm/cluster-vsphere/templates/machinedeployment.yaml
@@ -1,4 +1,5 @@
-{{- range $name, $value := .Values.global.nodePools }}
+{{- range $name, $value := include "createMapOfWorkerPoolSpecs" . | fromYaml }}
+{{- $c := (merge (dict "currentPool"  $value) $.Values) }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -29,7 +30,7 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: VSphereMachineTemplate
-        name: {{ include "resource.default.name" $ }}-{{ $value.class }}-{{ include "mtRevisionByClass" (merge (dict "currentValues" $.Values) $value) }}
+        name: {{ include "resource.default.name" $ }}-{{ $value.name }}-{{ include "mtRevision" $c }}
         namespace: {{ $.Release.Namespace }}
       version: {{ $.Values.internal.kubernetesVersion }}
 {{- end }}

--- a/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
+++ b/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
@@ -12,4 +12,5 @@ spec:
   template:
     spec:
       {{- include "mtSpec" $c | nindent 6 -}}
+
 {{- end }}

--- a/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
+++ b/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
@@ -12,5 +12,4 @@ spec:
   template:
     spec:
       {{- include "mtSpec" $c | nindent 6 -}}
-
 {{- end }}

--- a/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
+++ b/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
@@ -1,4 +1,4 @@
-{{- range $name, $value := include "createMapOfNodeSpecs" . | fromYaml }}
+{{- range $name, $value := include "createMapOfClusterNodeSpecs" . | fromYaml }}
 {{- $c := (merge (dict "currentPool"  $value) $.Values) }}
 ---
 apiVersion: {{ include "infrastructureApiVersion" . }}

--- a/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
+++ b/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
@@ -1,4 +1,4 @@
-{{- range $name, $value := (merge .Values.global.nodeClasses (dict "control-plane" .Values.global.controlPlane.machineTemplate)) }}
+{{- range $name, $value := include "createMapOfNodeSpecs" . | fromYaml }}
 {{- $c := (merge (dict "currentClass"  $value) $.Values) }}
 ---
 apiVersion: {{ include "infrastructureApiVersion" . }}

--- a/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
+++ b/helm/cluster-vsphere/templates/vspheremachinetemplate.yaml
@@ -1,5 +1,5 @@
 {{- range $name, $value := include "createMapOfNodeSpecs" . | fromYaml }}
-{{- $c := (merge (dict "currentClass"  $value) $.Values) }}
+{{- $c := (merge (dict "currentPool"  $value) $.Values) }}
 ---
 apiVersion: {{ include "infrastructureApiVersion" . }}
 kind: VSphereMachineTemplate

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -13,6 +13,15 @@
             },
             "minItems": 1
         },
+        "cloneMode": {
+            "type": "string",
+            "title": "VM template clone mode",
+            "enum": [
+                "fullClone",
+                "linkedClone"
+            ],
+            "default": "linkedClone"
+        },
         "diskGiB": {
             "type": "integer",
             "title": "Disk size",
@@ -403,10 +412,8 @@
                             "additionalProperties": false,
                             "properties": {
                                 "cloneMode": {
-                                    "type": "string",
-                                    "title": "Template clone mode",
-                                    "description": "VM template cloning method.",
-                                    "default": "linkedClone"
+                                    "$ref": "#/$defs/cloneMode",
+                                    "description": "VM template cloning method."
                                 },
                                 "diskGiB": {
                                     "$ref": "#/$defs/diskGiB",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -553,11 +553,10 @@
                     "description": "Groups of worker nodes with identical configuration.",
                     "additionalProperties": false,
                     "properties": {
-                        "def00": {
+                        "worker": {
                             "type": "object",
                             "title": "Default nodePool",
                             "required": [
-                                "diskGiB",
                                 "network"
                             ],
                             "additionalProperties": false,
@@ -574,11 +573,6 @@
                                     "$ref": "#/$defs/memoryGiB",
                                     "description": "Worker memory size, in MB.",
                                     "default": 16896
-                                },
-                                "name": {
-                                    "type": "string",
-                                    "title": "Nodepool name",
-                                    "default": "def00"
                                 },
                                 "network": {
                                     "$ref": "#/$defs/network",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -552,6 +552,11 @@
                     "title": "Node pools",
                     "description": "Groups of worker nodes with identical configuration.",
                     "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-z0-9-]{3,10}$": {
+                            "type": "object"
+                        }
+                    },
                     "properties": {
                         "default": {
                             "type": "object",

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -610,7 +610,7 @@
                         }
                     },
                     "properties": {
-                        "worker": {
+                        "def00": {
                             "type": "object",
                             "title": "Default nodePool",
                             "additionalProperties": false,

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -117,7 +117,8 @@
             "type": "object",
             "title": "Properties that are available to all charts and subcharts",
             "required": [
-                "metadata"
+                "metadata",
+                "nodePools"
             ],
             "properties": {
                 "connectivity": {
@@ -589,43 +590,56 @@
                     "title": "Node pools",
                     "description": "Groups of worker nodes with identical configuration.",
                     "additionalProperties": false,
-                    "patternProperties": {
-                        "^[a-z0-9-]{3,10}$": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "class": {
-                                    "type": "string",
-                                    "title": "Node class",
-                                    "description": "A valid node class name.",
-                                    "pattern": "^[a-z0-9-]+$"
-                                },
-                                "replicas": {
-                                    "type": "integer",
-                                    "title": "Number of nodes",
-                                    "default": 1,
-                                    "minimum": 1
-                                }
-                            }
-                        }
-                    },
                     "properties": {
                         "def00": {
                             "type": "object",
                             "title": "Default nodePool",
+                            "required": [
+                                "diskGiB",
+                                "network"
+                            ],
                             "additionalProperties": false,
                             "properties": {
-                                "class": {
+                                "cloneMode": {
+                                    "$ref": "#/$defs/cloneMode",
+                                    "description": "VM template cloning method."
+                                },
+                                "diskGiB": {
+                                    "$ref": "#/$defs/diskGiB",
+                                    "description": "Worker node root volume size, in GB."
+                                },
+                                "memoryMiB": {
+                                    "$ref": "#/$defs/memoryGiB",
+                                    "description": "Worker memory size, in MB.",
+                                    "default": 16896
+                                },
+                                "name": {
                                     "type": "string",
-                                    "title": "Node class",
-                                    "description": "A valid node class name.",
-                                    "default": "default"
+                                    "title": "Nodepool name",
+                                    "default": "def00"
+                                },
+                                "network": {
+                                    "$ref": "#/$defs/network",
+                                    "description": "Worker node network configuration."
+                                },
+                                "numCPUs": {
+                                    "$ref": "#/$defs/numCPUs",
+                                    "description": "Worker node CPU count.",
+                                    "default": 6
                                 },
                                 "replicas": {
                                     "type": "integer",
                                     "title": "Number of nodes",
                                     "default": 2,
                                     "minimum": 1
+                                },
+                                "resourcePool": {
+                                    "$ref": "#/$defs/resourcePool",
+                                    "description": "Name of the resource pool to use."
+                                },
+                                "template": {
+                                    "$ref": "#/$defs/template",
+                                    "description": "Full name of the VM template."
                                 }
                             }
                         }

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -540,51 +540,6 @@
                         }
                     }
                 },
-                "nodeClasses": {
-                    "type": "object",
-                    "title": "Template to define worker nodes",
-                    "properties": {
-                        "default": {
-                            "type": "object",
-                            "title": "Default node class configuration",
-                            "additionalProperties": false,
-                            "properties": {
-                                "cloneMode": {
-                                    "type": "string",
-                                    "title": "Template clone mode",
-                                    "description": "VM template cloning method.",
-                                    "default": "linkedClone"
-                                },
-                                "diskGiB": {
-                                    "$ref": "#/$defs/diskGiB",
-                                    "description": "Worker node root volume size, in GB."
-                                },
-                                "memoryMiB": {
-                                    "$ref": "#/$defs/memoryGiB",
-                                    "description": "Worker memory size, in MB.",
-                                    "default": 16896
-                                },
-                                "network": {
-                                    "$ref": "#/$defs/network",
-                                    "description": "Worker node network configuration."
-                                },
-                                "numCPUs": {
-                                    "$ref": "#/$defs/numCPUs",
-                                    "description": "Worker node CPU count.",
-                                    "default": 6
-                                },
-                                "resourcePool": {
-                                    "$ref": "#/$defs/resourcePool",
-                                    "description": "Name of the resource pool to use."
-                                },
-                                "template": {
-                                    "$ref": "#/$defs/template",
-                                    "description": "Full name of the VM template."
-                                }
-                            }
-                        }
-                    }
-                },
                 "nodePools": {
                     "type": "object",
                     "title": "Node pools",

--- a/helm/cluster-vsphere/values.schema.json.backup
+++ b/helm/cluster-vsphere/values.schema.json.backup
@@ -13,15 +13,6 @@
             },
             "minItems": 1
         },
-        "cloneMode": {
-            "type": "string",
-            "title": "VM template clone mode",
-            "enum": [
-                "fullClone",
-                "linkedClone"
-            ],
-            "default": "linkedClone"
-        },
         "diskGiB": {
             "type": "integer",
             "title": "Disk size",
@@ -126,8 +117,7 @@
             "type": "object",
             "title": "Properties that are available to all charts and subcharts",
             "required": [
-                "metadata",
-                "nodePools"
+                "metadata"
             ],
             "properties": {
                 "connectivity": {
@@ -194,39 +184,6 @@
                                 }
                             },
                             "default": {}
-                        },
-                        "localRegistryCache": {
-                            "type": "object",
-                            "title": "Local registry cache",
-                            "description": "Caching container registry within the cluster.",
-                            "required": [
-                                "enabled",
-                                "port"
-                            ],
-                            "additionalProperties": false,
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean",
-                                    "title": "Enable",
-                                    "description": "Enabling this will deploy the Zot registry service in the cluster. To make use of it as a pull-through cache, you also have to specify registries to cache images for.",
-                                    "default": false
-                                },
-                                "mirroredRegistries": {
-                                    "type": "array",
-                                    "title": "Registries to cache",
-                                    "description": "Here you must specify each registry to cache container images for. Please also make sure to have an entry for each registry in Global > Components > Containerd > Container registries.",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "default": []
-                                },
-                                "port": {
-                                    "type": "integer",
-                                    "title": "Service port",
-                                    "description": "NodePort used by the local registry service.",
-                                    "default": 32767
-                                }
-                            }
                         },
                         "network": {
                             "type": "object",
@@ -412,8 +369,10 @@
                             "additionalProperties": false,
                             "properties": {
                                 "cloneMode": {
-                                    "$ref": "#/$defs/cloneMode",
-                                    "description": "VM template cloning method."
+                                    "type": "string",
+                                    "title": "Template clone mode",
+                                    "description": "VM template cloning method.",
+                                    "default": "linkedClone"
                                 },
                                 "diskGiB": {
                                     "$ref": "#/$defs/diskGiB",
@@ -426,7 +385,13 @@
                                 },
                                 "network": {
                                     "$ref": "#/$defs/network",
-                                    "description": "Control plane node network configuration."
+                                    "description": "Control plane node network configuration.",
+                                    "default": [
+                                        {
+                                            "dhcp4": true,
+                                            "networkName": ""
+                                        }
+                                    ]
                                 },
                                 "numCPUs": {
                                     "$ref": "#/$defs/numCPUs",
@@ -548,58 +513,64 @@
                     }
                 },
                 "nodePools": {
-                    "type": "object",
+                    "type": "array",
                     "title": "Node pools",
-                    "description": "Groups of worker nodes with identical configuration.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "default": {
-                            "type": "object",
-                            "title": "Default nodePool",
-                            "required": [
-                                "network"
-                            ],
-                            "additionalProperties": false,
-                            "properties": {
-                                "cloneMode": {
-                                    "$ref": "#/$defs/cloneMode",
-                                    "description": "VM template cloning method."
-                                },
-                                "diskGiB": {
-                                    "$ref": "#/$defs/diskGiB",
-                                    "description": "Worker node root volume size, in GB."
-                                },
-                                "memoryMiB": {
-                                    "$ref": "#/$defs/memoryGiB",
-                                    "description": "Worker memory size, in MB.",
-                                    "default": 16896
-                                },
-                                "network": {
-                                    "$ref": "#/$defs/network",
-                                    "description": "Worker node network configuration."
-                                },
-                                "numCPUs": {
-                                    "$ref": "#/$defs/numCPUs",
-                                    "description": "Worker node CPU count.",
-                                    "default": 6
-                                },
-                                "replicas": {
-                                    "type": "integer",
-                                    "title": "Number of nodes",
-                                    "default": 2,
-                                    "minimum": 1
-                                },
-                                "resourcePool": {
-                                    "$ref": "#/$defs/resourcePool",
-                                    "description": "Name of the resource pool to use."
-                                },
-                                "template": {
-                                    "$ref": "#/$defs/template",
-                                    "description": "Full name of the VM template."
-                                }
+                    "items": {
+                        "type": "object",
+                        "title": "Node pool",
+                        "additionalProperties": false
+                        "properties": {
+                            "cloneMode": {
+                                "type": "string",
+                                "title": "Template clone mode",
+                                "description": "VM template cloning method."
+                            },
+                            "diskGiB": {
+                                "$ref": "#/$defs/diskGiB",
+                                "description": "Worker node root volume size, in GB."
+                            },
+                            "memoryMiB": {
+                                "$ref": "#/$defs/memoryGiB",
+                                "description": "Worker memory size, in MB."
+                            },
+                            "network": {
+                                "$ref": "#/$defs/network",
+                                "description": "Worker node network configuration."
+                            },
+                            "numCPUs": {
+                                "$ref": "#/$defs/numCPUs",
+                                "description": "Worker node CPU count."
+                            },
+                            "replicas": {
+                                "type": "integer",
+                                "title": "Number of nodes",
+                                "minimum": 1
+                            },
+                            "resourcePool": {
+                                "$ref": "#/$defs/resourcePool",
+                                "description": "Name of the resource pool to use."
+                            },
+                            "template": {
+                                "$ref": "#/$defs/template",
+                                "description": "Full name of the VM template."
                             }
                         }
-                    }
+                    },
+                    "default": [
+                        {
+                            "cloneMode": "linkedClone",
+                            "memoryMiB": 16896
+                            "name": "def00",
+                            "network": [
+                                {
+                                    "dhcp4": true,
+                                    "networkName": ""
+                                }
+                            ],
+                            "numCPUs": 6,
+                            "replicas": 2
+                        }
+                    ]
                 },
                 "podSecurityStandards": {
                     "type": "object",

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -45,10 +45,9 @@ global:
     preventDeletion: false
     servicePriority: highest
   nodePools:
-    def00:
+    worker:
       cloneMode: linkedClone
       memoryMiB: 16896
-      name: def00
       network:
         devices:
           - dhcp4: true

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -44,21 +44,19 @@ global:
   metadata:
     preventDeletion: false
     servicePriority: highest
-  nodeClasses:
-    default:
+  nodePools:
+    def00:
       cloneMode: linkedClone
       memoryMiB: 16896
+      name: def00
       network:
         devices:
           - dhcp4: true
             networkName: ""
       numCPUs: 6
+      replicas: 2
       resourcePool: '*/Resources'
       template: flatcar-stable-3815.2.2-kube-v1.27.14-gs
-  nodePools:
-    worker:
-      class: default
-      replicas: 2
   podSecurityStandards:
     enforced: true
   providerSpecific:

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -45,7 +45,7 @@ global:
     preventDeletion: false
     servicePriority: highest
   nodePools:
-    worker:
+    default:
       cloneMode: linkedClone
       memoryMiB: 16896
       network:


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/31192

This PR moves values from nodeClasses into the nodePool definition and removes `nodeClasses` entirely.

I've tested the changes with `helm template` between this branch and main and the entire diff is below:

```
--- out/pre/cluster-vsphere/templates/kubeadmconfigtemplate.yaml	2024-06-28 11:25:50.448039014 +0100
+++ out/post/cluster-vsphere/templates/kubeadmconfigtemplate.yaml	2024-06-28 14:22:14.813508561 +0100
@@ -3,7 +3,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: pre-worker-5044604e
+  name: pre-default-c65e65f5
   namespace: default
   labels:
     app: "cluster-vsphere"
@@ -119,7 +119,7 @@
             eviction-soft-grace-period: "memory.available=5s"
             anonymous-auth: "true"

-            node-labels: "giantswarm.io/node-pool=worker"
+            node-labels: "giantswarm.io/node-pool=default"
       files:
         - path: /etc/ssh/trusted-user-ca-keys.pem
           permissions: "0600"
diff -ur out/pre/cluster-vsphere/templates/machinedeployment.yaml out/post/cluster-vsphere/templates/machinedeployment.yaml
--- out/pre/cluster-vsphere/templates/machinedeployment.yaml	2024-06-28 11:25:50.448039014 +0100
+++ out/post/cluster-vsphere/templates/machinedeployment.yaml	2024-06-28 14:22:14.813508561 +0100
@@ -3,7 +3,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
-  name: pre-worker
+  name: pre-default
   namespace: default
   labels:
     app: "cluster-vsphere"
@@ -35,12 +35,12 @@
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: pre-worker-5044604e
+          name: pre-default-9a2ac5d6
           namespace: default
       clusterName: pre
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: VSphereMachineTemplate
-        name: pre-default-81f02996
+        name: pre-default-aa5f34c9
         namespace: default
       version: v1.27.14
```
