### PR TITLE
unpause cluster in cleanup hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Unpause Cluster resource as part of cleanup hook after deletion in order to prevent leftover resources.
+
 ## [0.56.0] - 2024-07-10
 
 ### Changed

--- a/helm/cluster-vsphere/templates/helmreleases/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cleanup-helmreleases-hook-job.yaml
@@ -119,6 +119,9 @@ spec:
                 echo "Deleting helmchart $chart"
                 kubectl delete -n ${NAMESPACE} helmchart "${chart}" --ignore-not-found=true
               done
+
+              echo "Unpausing cluster ${CLUSTER_NAME}" to allow deletion..."
+              kubectl patch -n ${NAMESPACE} cluster "${CLUSTER_NAME}" --type=merge -p '{"spec": {"paused": false}}'
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
This pr: fixes a bug where a cluster is still paused on deletion and therefore not cleaned up properly.

https://github.com/giantswarm/giantswarm/issues/31319

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
