### PR TITLE
Update ipam API versions to v1beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `ipam` API versions to `v1beta1`.
+
 ## [0.57.1] - 2024-07-24
 
 ## [0.57.0] - 2024-07-22

--- a/helm/cluster-vsphere/templates/ipam/_ipam.tpl
+++ b/helm/cluster-vsphere/templates/ipam/_ipam.tpl
@@ -1,13 +1,13 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{- define "isIpamControlPlaneIPEnabled" -}}
-    {{- if and (and (not .Values.global.connectivity.network.controlPlaneEndpoint.host) (.Values.global.connectivity.network.controlPlaneEndpoint.ipPoolName)) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1alpha1/IPAddressClaim") }}
+    {{- if and (and (not .Values.global.connectivity.network.controlPlaneEndpoint.host) (.Values.global.connectivity.network.controlPlaneEndpoint.ipPoolName)) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1beta1/IPAddressClaim") }}
         {{- printf "true" -}}
     {{- end }}
 {{- end }}
 
 {{- define "isIpamSvcLoadBalancerEnabled" -}}
-    {{- if and (.Values.global.connectivity.network.loadBalancers.ipPoolName) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1alpha1/IPAddressClaim") }}
+    {{- if and (.Values.global.connectivity.network.loadBalancers.ipPoolName) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1beta1/IPAddressClaim") }}
         {{- printf "true" -}}
     {{- end }}
 {{- end }}

--- a/helm/cluster-vsphere/templates/ipam/ipAddressClaim.yaml
+++ b/helm/cluster-vsphere/templates/ipam/ipAddressClaim.yaml
@@ -1,5 +1,5 @@
 {{- if (include "isIpamControlPlaneIPEnabled" $) -}}
-apiVersion: ipam.cluster.x-k8s.io/v1alpha1
+apiVersion: ipam.cluster.x-k8s.io/v1beta1
 kind: IPAddressClaim
 metadata:
   name: {{ include "resource.default.name" $ }}

--- a/helm/cluster-vsphere/templates/ipam/ipAddressClaimLB.yaml
+++ b/helm/cluster-vsphere/templates/ipam/ipAddressClaimLB.yaml
@@ -1,5 +1,5 @@
 {{- if (include "isIpamSvcLoadBalancerEnabled" $) -}}
-apiVersion: ipam.cluster.x-k8s.io/v1alpha1
+apiVersion: ipam.cluster.x-k8s.io/v1beta1
 kind: IPAddressClaim
 metadata:
   name: {{ include "lbClaimName" $ }}


### PR DESCRIPTION
This pr:

Updates the API version for IPAM components as installation was failing when using v1alpha1. Required for [mc-bootstrap](https://github.com/giantswarm/mc-bootstrap/pull/934)

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
