### PR TITLE
set cluster api group in hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `cluster` in kubectl patch command to `cluster.cluster.x-k8s.io` inside hooks in case more than one API group is present.
+
 ## [0.58.0] - 2024-07-30
 
 ### Fixed

--- a/helm/cluster-vsphere/templates/helmreleases/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cleanup-helmreleases-hook-job.yaml
@@ -121,7 +121,7 @@ spec:
               done
 
               echo "Unpausing cluster ${CLUSTER_NAME} to allow deletion..."
-              kubectl patch -n ${NAMESPACE} cluster "${CLUSTER_NAME}" --type=merge -p '{"spec": {"paused": false}}'
+              kubectl patch -n ${NAMESPACE} cluster.cluster.x-k8s.io "${CLUSTER_NAME}" --type=merge -p '{"spec": {"paused": false}}'
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
+++ b/helm/cluster-vsphere/templates/ipam/assign-ip-pre-install-job.yaml
@@ -45,7 +45,7 @@ spec:
           command:
             - "/bin/bash"
             - "-xc"
-            - kubectl patch cluster -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }} --type=merge -p '{"spec":{"paused":true}}'
+            - kubectl patch cluster.cluster.x-k8s.io -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }} --type=merge -p '{"spec":{"paused":true}}'
 {{- if (include "isIpamSvcLoadBalancerEnabled" $) }}
             - kubectl patch helmrelease -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }}-cloud-provider-vsphere --type=merge -p '{"spec":{"suspend":true}}'
 {{- end }}
@@ -146,6 +146,6 @@ spec:
               set -o nounset
               echo "New IPs have been assigned, upausing the Cluster '{{ include "resource.default.name" $ }}' resource.."
               kubectl get ipaddresses.ipam.cluster.x-k8s.io -n {{ $.Release.Namespace }}
-              kubectl patch cluster -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }} --type=merge -p '{"spec":{"paused":false}}'
+              kubectl patch cluster.cluster.x-k8s.io -n {{ $.Release.Namespace }} {{ include "resource.default.name" $ }} --type=merge -p '{"spec":{"paused":false}}'
 ---
 {{- end }}


### PR DESCRIPTION
related https://github.com/giantswarm/roadmap/issues/3619

This pr: fixes the hooks failing due to ambiguous api groups on some MCs (specifically this is the case on goat)

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
