### PR TITLE
Fix IPAM for service load balancers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable IPAM for service load balancers if `.global.connectivity.network.loadBalancers.cidrBlocks` is set.
+
 ## [0.58.1] - 2024-07-31
 
 ### Changed

--- a/helm/cluster-vsphere/templates/ipam/_ipam.tpl
+++ b/helm/cluster-vsphere/templates/ipam/_ipam.tpl
@@ -7,7 +7,7 @@
 {{- end }}
 
 {{- define "isIpamSvcLoadBalancerEnabled" -}}
-    {{- if and (.Values.global.connectivity.network.loadBalancers.ipPoolName) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1beta1/IPAddressClaim") }}
+    {{- if and (and (not .Values.global.connectivity.network.loadBalancers.cidrBlocks) (.Values.global.connectivity.network.loadBalancers.ipPoolName)) (.Capabilities.APIVersions.Has "ipam.cluster.x-k8s.io/v1beta1/IPAddressClaim") }}
         {{- printf "true" -}}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
We have default for `.global.connectivity.network.loadBalancers.ipPoolName` and it is not easy to set it empty to disable IPAM. On the other hand, we set `.global.connectivity.network.loadBalancers.cidrBlocks` when we don't want to use IPAM. Thanks to this additional check, we don't have to overwrite the `.global.connectivity.network.loadBalancers.ipPoolNam` with null.

/run cluster-test-suites
