### PR TITLE
enable add properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow additional properties on machine templates to offer wider CAPV configurations.
+
 ## [0.58.2] - 2024-08-01
 
 ### Changed

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -461,7 +461,7 @@
                             "required": [
                                 "network"
                             ],
-                            "additionalProperties": false,
+                            "additionalProperties": true,
                             "properties": {
                                 "cloneMode": {
                                     "$ref": "#/$defs/cloneMode",
@@ -620,7 +620,7 @@
                             "required": [
                                 "network"
                             ],
-                            "additionalProperties": false,
+                            "additionalProperties": true,
                             "properties": {
                                 "cloneMode": {
                                     "$ref": "#/$defs/cloneMode",


### PR DESCRIPTION
Our customer requires to place the VMs in a specific folder which is not exposed in the interface. Rather than supporting every configuration field in CAPV (there are a lot), we can open it.