### PR TITLE
 Set cilium kubeProxyReplacement to 'true'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `kubeProxyReplacement` to `'true'` instead of deprecated value `strict` in cilium values.
+
 ## [0.58.3] - 2024-08-04
 
 ### Changed

--- a/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
       mode: kubernetes
     k8sServiceHost: api.{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}
     k8sServicePort: "6443"
-    kubeProxyReplacement: true
+    kubeProxyReplacement: 'true'
     global:
       podSecurityStandards:
         enforced: {{ .Values.global.podSecurityStandards.enforced }}

--- a/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cilium-helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
       mode: kubernetes
     k8sServiceHost: api.{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}
     k8sServicePort: "6443"
-    kubeProxyReplacement: strict
+    kubeProxyReplacement: true
     global:
       podSecurityStandards:
         enforced: {{ .Values.global.podSecurityStandards.enforced }}


### PR DESCRIPTION
Upstream marked 'strict' as deprecated in 1.15 and will remove it completely in 1.16.

See also cilium/cilium#32711

Signed-off-by: Matias Charriere <matias@giantswarm.io>

Towards https://github.com/giantswarm/giantswarm/issues/31353

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
