### PR TITLE
configurable storage class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Set `kubeProxyReplacement` to `'true'` instead of deprecated value `strict` in cilium values.
+- Make default storage class configurable.
 
 ## [0.58.3] - 2024-08-04
 

--- a/helm/cluster-vsphere/README.md
+++ b/helm/cluster-vsphere/README.md
@@ -164,7 +164,7 @@ Properties within the `.global.providerSpecific` object
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `global.providerSpecific.defaultStorageClass` | **Default Storage Class** - Configuration of the default storage class.|**Type:** `object`<br/>|
-| `global.providerSpecific.defaultStorageClass.enabled` | **Enable default storage class** - Creates a default storage class if set to true|**Type:** `boolean`<br/>**Default:** `true`|
+| `global.providerSpecific.defaultStorageClass.enabled` | **Enable default storage class** - Creates a default storage class if set to true.|**Type:** `boolean`<br/>**Default:** `true`|
 | `global.providerSpecific.defaultStorageClass.reclaimPolicy` | **Reclaim Policy** - Reclaim policy of the storage class (Delete or Retain).|**Type:** `string`<br/>**Default:** `"Delete"`|
 | `global.providerSpecific.defaultStorageClass.storagePolicyName` | **Storage Policy name** - Name of the vSphere storage policy to use in the storage class. Leave empty for no storage policy.|**Type:** `string`<br/>**Default:** `""`|
 | `global.providerSpecific.vcenter` | **VCenter** - Configuration for vSphere API access.|**Type:** `object`<br/>|

--- a/helm/cluster-vsphere/README.md
+++ b/helm/cluster-vsphere/README.md
@@ -163,6 +163,10 @@ Properties within the `.global.providerSpecific` object
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
+| `global.providerSpecific.defaultStorageClass` | **Default Storage Class** - Configuration of the default storage class.|**Type:** `object`<br/>|
+| `global.providerSpecific.defaultStorageClass.enabled` | **Enable default storage class** - Creates a default storage class if set to true|**Type:** `boolean`<br/>**Default:** `true`|
+| `global.providerSpecific.defaultStorageClass.reclaimPolicy` | **Reclaim Policy** - Reclaim policy of the storage class (Delete or Retain).|**Type:** `string`<br/>**Default:** `"Delete"`|
+| `global.providerSpecific.defaultStorageClass.storagePolicyName` | **Storage Policy name** - Name of the vSphere storage policy to use in the storage class. Leave empty for no storage policy.|**Type:** `string`<br/>**Default:** `""`|
 | `global.providerSpecific.vcenter` | **VCenter** - Configuration for vSphere API access.|**Type:** `object`<br/>|
 | `global.providerSpecific.vcenter.datacenter` | **Datacenter** - Name of the datacenter to deploy nodes into.|**Type:** `string`<br/>|
 | `global.providerSpecific.vcenter.datastore` | **Datastore** - Name of the datastore for node disk storage.|**Type:** `string`<br/>|

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -56,3 +56,12 @@ spec:
         enforced: {{ .Values.global.podSecurityStandards.enforced }}
     kube-vip-cloud-provider:
       cidrGlobal: '{{ join "," .Values.global.connectivity.network.loadBalancers.cidrBlocks }}'
+    vsphere-csi-driver:
+      storageClass:
+        {{- with .Values.global.providerSpecific.defaultStorageClass }}
+        enabled: {{ .enabled }}
+        reclaimPolicy: {{ .reclaimPolicy }}
+        {{- if .storagePolicyName }}
+        storageProfileName: {{ .storagePolicyName }}
+        {{- end }}
+        {{- end }}

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -19,10 +19,10 @@ spec:
       chart: cloud-provider-vsphere
       # used by renovate
       # repo: giantswarm/cloud-provider-vsphere-app
-      version: 1.10.0-e20bc2c43b6e944c6c2f676b74cccc91ac3af933
+      version: 1.11.0
       sourceRef:
         kind: HelmRepository
-        name: {{ include "resource.default.name" $ }}-default-test
+        name: {{ include "resource.default.name" $ }}-default
   dependsOn:
     - name: {{ include "resource.default.name" $ }}-cilium
       namespace: {{ $.Release.Namespace }}

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -19,10 +19,10 @@ spec:
       chart: cloud-provider-vsphere
       # used by renovate
       # repo: giantswarm/cloud-provider-vsphere-app
-      version: 1.10.0
+      version: 1.10.0-e38fb941a79429463dfeefe586d40ab6a427de42
       sourceRef:
         kind: HelmRepository
-        name: {{ include "resource.default.name" $ }}-default
+        name: {{ include "resource.default.name" $ }}-default-test
   dependsOn:
     - name: {{ include "resource.default.name" $ }}-cilium
       namespace: {{ $.Release.Namespace }}

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
       chart: cloud-provider-vsphere
       # used by renovate
       # repo: giantswarm/cloud-provider-vsphere-app
-      version: 1.10.0-e38fb941a79429463dfeefe586d40ab6a427de42
+      version: 1.10.0-e20bc2c43b6e944c6c2f676b74cccc91ac3af933
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default-test

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -678,6 +678,35 @@
                     "type": "object",
                     "title": "Provider specific configuration",
                     "properties": {
+                        "defaultStorageClass": {
+                            "type": "object",
+                            "title": "Default Storage Class",
+                            "description": "Configuration of the default storage class.",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enable default storage class",
+                                    "description": "Creates a default storage class if set to true.",
+                                    "default": true
+                                },
+                                "reclaimPolicy": {
+                                    "type": "string",
+                                    "title": "Reclaim Policy",
+                                    "description": "Reclaim policy of the storage class (Delete or Retain).",
+                                    "enum": [
+                                        "Delete",
+                                        "Retain"
+                                    ],
+                                    "default": "Delete"
+                                },
+                                "storagePolicyName": {
+                                    "type": "string",
+                                    "title": "Storage Policy name",
+                                    "description": "Name of the vSphere storage policy to use in the storage class. Leave empty for no storage policy.",
+                                    "default": ""
+                                }
+                            }
+                        },
                         "vcenter": {
                             "type": "object",
                             "title": "VCenter",
@@ -722,35 +751,6 @@
                                     "type": "string",
                                     "title": "Zone",
                                     "description": "Category name in VSphere for topology.kubernetes.io/zone labels."
-                                }
-                            }
-                        },
-                        "defaultStorageClass": {
-                            "type": "object",
-                            "title": "Default Storage Class",
-                            "description": "Configuration of the default storage class.",
-                            "properties": {
-                                "storagePolicyName": {
-                                    "type": "string",
-                                    "title": "Storage Policy name",
-                                    "description": "Name of the vSphere storage policy to use in the storage class. Leave empty for no storage policy.",
-                                    "default": ""
-                                },
-                                "reclaimPolicy": {
-                                    "type": "string",
-                                    "title": "Reclaim Policy",
-                                    "description": "Reclaim policy of the storage class (Delete or Retain).",
-                                    "default": "Delete",
-                                    "enum": [
-                                        "Delete",
-                                        "Retain"
-                                    ]
-                                },
-                                "enabled": {
-                                    "type": "boolean",
-                                    "title": "Enable default storage class",
-                                    "description": "Creates a default storage class if set to true.",
-                                    "default": true
                                 }
                             }
                         }

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -749,7 +749,7 @@
                                 "enabled": {
                                     "type": "boolean",
                                     "title": "Enable default storage class",
-                                    "description": "Creates a default storage class if set to true",
+                                    "description": "Creates a default storage class if set to true.",
                                     "default": true
                                 }
                             }

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -724,6 +724,35 @@
                                     "description": "Category name in VSphere for topology.kubernetes.io/zone labels."
                                 }
                             }
+                        },
+                        "defaultStorageClass": {
+                            "type": "object",
+                            "title": "Default Storage Class",
+                            "description": "Configuration of the default storage class.",
+                            "properties": {
+                                "storagePolicyName": {
+                                    "type": "string",
+                                    "title": "Storage Policy name",
+                                    "description": "Name of the vSphere storage policy to use in the storage class. Leave empty for no storage policy.",
+                                    "default": ""
+                                },
+                                "reclaimPolicy": {
+                                    "type": "string",
+                                    "title": "Reclaim Policy",
+                                    "description": "Reclaim policy of the storage class (Delete or Retain).",
+                                    "default": "Delete",
+                                    "enum": [
+                                        "Delete",
+                                        "Retain"
+                                    ]
+                                },
+                                "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enable default storage class",
+                                    "description": "Creates a default storage class if set to true",
+                                    "default": true
+                                }
+                            }
                         }
                     }
                 }

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -92,11 +92,11 @@ global:
   podSecurityStandards:
     enforced: true
   providerSpecific:
-    vcenter: {}
     defaultStorageClass:
-      storagePolicyName: ""
-      reclaimPolicy: Delete
       enabled: true
+      reclaimPolicy: Delete
+      storagePolicyName: ""
+    vcenter: {}
 internal:
   apiServer:
     certSANs: []

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -93,6 +93,10 @@ global:
     enforced: true
   providerSpecific:
     vcenter: {}
+    defaultStorageClass:
+      storagePolicyName: ""
+      reclaimPolicy: Delete
+      enabled: true
 internal:
   apiServer:
     certSANs: []


### PR DESCRIPTION
This pr adds the capability to specify a storage policy or none for the default vSphere csi storage class. Setting no storage policy is required in some cases.

It is also possible to not create a default policy and set the reclaimPolicy. Here we only create one SC as we never really used the reclaim policy.

The idea is to offer the customer the ability to easily create a default SC, other SCs can be created manually.

Consumes https://github.com/giantswarm/cloud-provider-vsphere-app/pull/136

Towards https://github.com/giantswarm/roadmap/issues/3626

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
