### PR TITLE
Use Renovate to update kube-vip static pod manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use Renovate to update `kube-vip` static pod manifest.
+
 ## [0.65.2] - 2024-10-28
 
 ### Fixed

--- a/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
+++ b/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
@@ -36,6 +36,8 @@ stringData:
           value: "10"
         - name: vip_retryperiod
           value: "2"
+        # used by renovate
+        # repo: kube-vip/kube-vip
         image: gsoci.azurecr.io/giantswarm/kube-vip:v0.8.3
         imagePullPolicy: IfNotPresent
         name: kube-vip


### PR DESCRIPTION
This PR:

- adds the renovate tag to ensure the kube-vip static pod manifest is updated automatically.
