### PR TITLE
`kube-vip`: Remove Renovate annotation.

### DIFF
--- a/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
+++ b/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
@@ -40,8 +40,6 @@ stringData:
           value: "10"
         - name: vip_retryperiod
           value: "2"
-        # used by renovate
-        # repo: kube-vip/kube-vip
         image: gsoci.azurecr.io/giantswarm/kube-vip:v0.8.3
         imagePullPolicy: IfNotPresent
         name: kube-vip


### PR DESCRIPTION
It currently causes Renovate to always open two PRs:

https://github.com/giantswarm/cluster-vsphere/pull/303
https://github.com/giantswarm/cluster-vsphere/pull/310