### PR TITLE
Make cloud-provider-vsphere HelmRelease catalog configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-
-
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -12,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update example manifest.
+- Make cloud-provider-vsphere HelmRelease catalog configurable.
 
 ## [0.68.0] - 2024-12-11
 

--- a/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
+++ b/helm/cluster-vsphere/templates/helmreleases/cloud-provider-vsphere-helmrelease.yaml
@@ -18,11 +18,10 @@ spec:
     spec:
       chart: cloud-provider-vsphere
       {{- $_ := set $ "appName" "cloud-provider-vsphere" }}
-      {{- $appVersion := include "cluster.app.version" $ }}
-      version: {{ $appVersion }}
+      version: {{ include "cluster.app.version" $ }}
       sourceRef:
         kind: HelmRepository
-        name: {{ include "resource.default.name" $ }}-default
+        name: {{ include "resource.default.name" $ }}-{{ include "cluster.app.catalog" $ }}
   dependsOn:
     - name: {{ include "resource.default.name" $ }}-cilium
       namespace: {{ $.Release.Namespace }}


### PR DESCRIPTION
This pr:

Allows the CPI helmrelease to pick up the catalog from the Release CRD.
