### PR TITLE
add-template-suffix-field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `global.providerSpecific.templateSuffix` to set a suffix on the VM template to use.
+
 ## [0.69.0] - 2025-03-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -38,3 +38,12 @@ The ID should look like this: `urn:vmomi:InventoryServiceTag:a5242a12-87e4-4954-
           tagIDs:
           - "urn:vmomi:InventoryServiceTag:827c9b5a-e6e5-4c3f-8349-29c083395a7f:GLOBAL"
 ```
+
+## Using a VM template per location
+
+When there are clusters in different geographical locations under the same `datacenter` entity, it is recommended to use a VM template stored in that cluster to avoid cloning over a WAN connection.
+
+In this case:
+
+- Set e.g. `global.providerSpecific.templateSuffix=paris`
+- Upload the VM image template to the Paris cluster and rename it to add the `-paris` suffix.

--- a/helm/cluster-vsphere/README.md
+++ b/helm/cluster-vsphere/README.md
@@ -178,6 +178,7 @@ Properties within the `.global.providerSpecific` object
 | `global.providerSpecific.defaultStorageClass.enabled` | **Enable default storage class** - Creates a default storage class if set to true.|**Type:** `boolean`<br/>**Default:** `true`|
 | `global.providerSpecific.defaultStorageClass.reclaimPolicy` | **Reclaim Policy** - Reclaim policy of the storage class (Delete or Retain).|**Type:** `string`<br/>**Default:** `"Delete"`|
 | `global.providerSpecific.defaultStorageClass.storagePolicyName` | **Storage Policy name** - Name of the vSphere storage policy to use in the storage class. Leave empty for no storage policy.|**Type:** `string`<br/>**Default:** `""`|
+| `global.providerSpecific.templateSuffix` | **Template suffix** - Suffix to append to the VM template name to find the correct template.|**Type:** `string`<br/>**Default:** `""`|
 | `global.providerSpecific.vcenter` | **VCenter** - Configuration for vSphere API access.|**Type:** `object`<br/>|
 | `global.providerSpecific.vcenter.datacenter` | **Datacenter** - Name of the datacenter to deploy nodes into.|**Type:** `string`<br/>|
 | `global.providerSpecific.vcenter.datastore` | **Datastore** - Name of the datastore for node disk storage.|**Type:** `string`<br/>|

--- a/helm/cluster-vsphere/ci/ci-values.yaml
+++ b/helm/cluster-vsphere/ci/ci-values.yaml
@@ -37,6 +37,7 @@ global:
           - networkName: 'grasshopper-capv'
             dhcp4: true
   providerSpecific:
+    # templateSuffix: "paris"
     vcenter:
       server: "https://foo.example.com"
       username: "vcenter-admin"

--- a/helm/cluster-vsphere/templates/helpers/_controlplane.tpl
+++ b/helm/cluster-vsphere/templates/helpers/_controlplane.tpl
@@ -10,9 +10,10 @@ Generates template spec for control plane machines.
 {{- $osVersion := include "cluster.os.version" $ }}
 {{- $kubernetesVersion := include "cluster.component.kubernetes.version" $ }}
 {{- $osToolingVersion := include "cluster.os.tooling.version" $ }}
+{{- $templateSuffix := $.Values.global.providerSpecific.templateSuffix }}
 
 {{- /* Modify $d.global.controlPlane.machineTemplate.template here */ -}}
-{{- $templateValue := printf "%s-%s-%s-kube-%s-tooling-%s-gs" $osName $osReleaseChannel $osVersion $kubernetesVersion $osToolingVersion -}}
+{{- $templateValue := printf "%s-%s-%s-kube-%s-tooling-%s-gs-%s" $osName $osReleaseChannel $osVersion $kubernetesVersion $osToolingVersion $templateSuffix | trimSuffix "-" -}}
 {{- $_ := set $d.global.controlPlane.machineTemplate "template" $templateValue -}}
 
 datacenter: {{ $d.global.providerSpecific.vcenter.datacenter }}

--- a/helm/cluster-vsphere/templates/helpers/_workers.tpl
+++ b/helm/cluster-vsphere/templates/helpers/_workers.tpl
@@ -8,9 +8,10 @@
 {{- $osVersion := include "cluster.os.version" $ }}
 {{- $kubernetesVersion := include "cluster.component.kubernetes.version" $ }}
 {{- $osToolingVersion := include "cluster.os.tooling.version" $ }}
+{{- $templateSuffix := $.Values.global.providerSpecific.templateSuffix }}
 
 {{- /* Modify $pool.template here */ -}}
-{{- $templateValue := printf "%s-%s-%s-kube-%s-tooling-%s-gs" $osName $osReleaseChannel $osVersion $kubernetesVersion $osToolingVersion -}}
+{{- $templateValue := printf "%s-%s-%s-kube-%s-tooling-%s-gs-%s" $osName $osReleaseChannel $osVersion $kubernetesVersion $osToolingVersion $templateSuffix | trimSuffix "-" -}}
 {{- $_ := set $pool "template" $templateValue -}}
 
 datacenter: {{ $.Values.global.providerSpecific.vcenter.datacenter }}

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -1011,6 +1011,12 @@
                                 }
                             }
                         },
+                        "templateSuffix": {
+                            "type": "string",
+                            "title": "Template suffix",
+                            "description": "Suffix to append to the VM template name to find the correct template.",
+                            "default": ""
+                        },
                         "vcenter": {
                             "type": "object",
                             "title": "VCenter",

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -260,6 +260,7 @@ global:
       enabled: true
       reclaimPolicy: Delete
       storagePolicyName: ""
+    templateSuffix: ""
     vcenter: {}
   release: {}
 internal:


### PR DESCRIPTION
This pr adds a field to add a suffix to the vSphere VM template name to clone the node VMs from.

Towards https://github.com/giantswarm/giantswarm/issues/32591

Setting `global.providerSpecific.templateSuffix=paris` will generate:

```yaml
template: flatcar-stable-N/A-kube-N/A-tooling-N/A-gs-paris
```

Not setting `global.providerSpecific.templateSuffix` will generate:

```yaml
template: flatcar-stable-N/A-kube-N/A-tooling-N/A-gs
```

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites
