### PR TITLE
consume ntpd custer chart test version

### DIFF
--- a/helm/cluster-vsphere/Chart.lock
+++ b/helm/cluster-vsphere/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cluster
-  repository: https://giantswarm.github.io/cluster-catalog
-  version: 2.2.0
+  repository: https://giantswarm.github.io/cluster-test-catalog
+  version: 2.2.0-b1f89df01400b74bf6399776f951c0769b84668a
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.7.1
-digest: sha256:03f96030f0431911d8ae3990ebdffa5efbd7c33b388e32ee53b74fd9f5db9267
-generated: "2025-03-18T10:54:50.650907083Z"
+digest: sha256:65ebcf6db813d337bcfdba6ccba6c30d0a3b88f762eeea88471ceec86d39e64d
+generated: "2025-04-10T15:48:46.901505+02:00"

--- a/helm/cluster-vsphere/Chart.yaml
+++ b/helm/cluster-vsphere/Chart.yaml
@@ -20,8 +20,8 @@ restrictions:
     - vsphere
 dependencies:
   - name: cluster
-    version: "2.2.0"
-    repository: "https://giantswarm.github.io/cluster-catalog"
+    version: "2.2.0-b1f89df01400b74bf6399776f951c0769b84668a"
+    repository: "https://giantswarm.github.io/cluster-test-catalog"
   - name: cluster-shared
     version: "0.7.1"
     repository: "https://giantswarm.github.io/cluster-catalog"


### PR DESCRIPTION
This pr: ..

### Trigger e2e tests
<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites
