### PR TITLE
update kube-vip staticpod template to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update `kube-vip` to `0.9.0`.
+
 ## [1.1.0] - 2025-03-18
 
 ### Changed

--- a/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
+++ b/helm/cluster-vsphere/templates/kubevip-staticpod-template.yaml
@@ -32,7 +32,7 @@ stringData:
           value: "true"
         - name: vip_address
           value: {{ .Values.global.connectivity.network.controlPlaneEndpoint.host }}
-        - name: vip_cidr
+        - name: vip_subnet
           value: "32"
         - name: vip_interface
           value: ens192
@@ -42,7 +42,7 @@ stringData:
           value: "10"
         - name: vip_retryperiod
           value: "2"
-        image: gsoci.azurecr.io/giantswarm/kube-vip:v0.8.10
+        image: gsoci.azurecr.io/giantswarm/kube-vip:v0.9.0
         imagePullPolicy: IfNotPresent
         name: kube-vip
         resources: {}


### PR DESCRIPTION
the latest kube-vip release has a [breaking change](https://github.com/kube-vip/kube-vip/releases/tag/v0.9.0) which needs to be fixed at the same time as the image upgrade.

closes https://github.com/giantswarm/cluster-vsphere/pull/356

/run cluster-test-suites
