### PR TITLE
chore(values): Remove dead container registry cache schema.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Values: Remove dead container registry cache schema.
+
 ### Added
 
 - Add support for Kamaji control planes.

--- a/helm/cluster-vsphere/README.md
+++ b/helm/cluster-vsphere/README.md
@@ -43,27 +43,13 @@ Advanced configuration of components that are running on all nodes.
 
 ### Connectivity
 Properties within the `.global.connectivity` object
-Configurations related to cluster connectivity such as container registries.
+Configurations related to cluster connectivity.
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `global.connectivity.baseDomain` | **Base DNS domain**|**Type:** `string`<br/>|
-| `global.connectivity.containerRegistries` | **Container registries** - Endpoints and credentials configuration for container registries.|**Type:** `object`<br/>**Default:** `{}`|
-| `global.connectivity.containerRegistries.*` |**None**|**Type:** `array`<br/>|
-| `global.connectivity.containerRegistries.*[*]` |**None**|**Type:** `object`<br/>|
-| `global.connectivity.containerRegistries.*[*].credentials` | **Credentials** - Credentials for the endpoint.|**Type:** `object`<br/>|
-| `global.connectivity.containerRegistries.*[*].credentials.auth` | **Auth** - Base64-encoded string from the concatenation of the username, a colon, and the password.|**Type:** `string`<br/>|
-| `global.connectivity.containerRegistries.*[*].credentials.identitytoken` | **Identity token** - Used to authenticate the user and obtain an access token for the registry.|**Type:** `string`<br/>|
-| `global.connectivity.containerRegistries.*[*].credentials.password` | **Password** - Used to authenticate for the registry with username/password.|**Type:** `string`<br/>|
-| `global.connectivity.containerRegistries.*[*].credentials.username` | **Username** - Used to authenticate for the registry with username/password.|**Type:** `string`<br/>|
-| `global.connectivity.containerRegistries.*[*].endpoint` | **Endpoint** - Endpoint for the container registry.|**Type:** `string`<br/>|
 | `global.connectivity.dns` | **DNS**|**Type:** `object`<br/>|
 | `global.connectivity.dns.wildcardCnameTarget` | **Wildcard CNAME Target** - Override the wildcard CNAME record value. If no value is passed defaults to "ingress". Only subdomains from the cluster DNS zone are valid.|**Type:** `string`<br/>**Example:** `"gateway"`<br/>|
-| `global.connectivity.localRegistryCache` | **Local registry cache** - Caching container registry within the cluster.|**Type:** `object`<br/>|
-| `global.connectivity.localRegistryCache.enabled` | **Enable** - Enabling this will deploy the Zot registry service in the cluster. To make use of it as a pull-through cache, you also have to specify registries to cache images for.|**Type:** `boolean`<br/>**Default:** `false`|
-| `global.connectivity.localRegistryCache.mirroredRegistries` | **Registries to cache** - Here you must specify each registry to cache container images for. Please also make sure to have an entry for each registry in Global > Components > Containerd > Container registries.|**Type:** `array`<br/>**Default:** `[]`|
-| `global.connectivity.localRegistryCache.mirroredRegistries[*]` |**None**|**Type:** `string`<br/>|
-| `global.connectivity.localRegistryCache.port` | **Service port** - NodePort used by the local registry service.|**Type:** `integer`<br/>**Default:** `32767`|
 | `global.connectivity.network` | **Network**|**Type:** `object`<br/>|
 | `global.connectivity.network.controlPlaneEndpoint` | **Endpoint** - Kubernetes API configuration.|**Type:** `object`<br/>|
 | `global.connectivity.network.controlPlaneEndpoint.host` | **Host** - IP for access to the Kubernetes API. Manually select an IP for kube API. Empty string for auto selection from the ipPoolName pool.|**Type:** `string`<br/>|

--- a/helm/cluster-vsphere/values.schema.json
+++ b/helm/cluster-vsphere/values.schema.json
@@ -791,7 +791,7 @@
                 "connectivity": {
                     "type": "object",
                     "title": "Connectivity",
-                    "description": "Configurations related to cluster connectivity such as container registries.",
+                    "description": "Configurations related to cluster connectivity.",
                     "required": [
                         "baseDomain",
                         "network"
@@ -801,57 +801,6 @@
                         "baseDomain": {
                             "type": "string",
                             "title": "Base DNS domain"
-                        },
-                        "containerRegistries": {
-                            "type": "object",
-                            "title": "Container registries",
-                            "description": "Endpoints and credentials configuration for container registries.",
-                            "additionalProperties": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "required": [
-                                        "endpoint"
-                                    ],
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "credentials": {
-                                            "type": "object",
-                                            "title": "Credentials",
-                                            "description": "Credentials for the endpoint.",
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "auth": {
-                                                    "type": "string",
-                                                    "title": "Auth",
-                                                    "description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
-                                                },
-                                                "identitytoken": {
-                                                    "type": "string",
-                                                    "title": "Identity token",
-                                                    "description": "Used to authenticate the user and obtain an access token for the registry."
-                                                },
-                                                "password": {
-                                                    "type": "string",
-                                                    "title": "Password",
-                                                    "description": "Used to authenticate for the registry with username/password."
-                                                },
-                                                "username": {
-                                                    "type": "string",
-                                                    "title": "Username",
-                                                    "description": "Used to authenticate for the registry with username/password."
-                                                }
-                                            }
-                                        },
-                                        "endpoint": {
-                                            "type": "string",
-                                            "title": "Endpoint",
-                                            "description": "Endpoint for the container registry."
-                                        }
-                                    }
-                                }
-                            },
-                            "default": {}
                         },
                         "dns": {
                             "type": "object",
@@ -865,39 +814,6 @@
                                     "examples": [
                                         "gateway"
                                     ]
-                                }
-                            }
-                        },
-                        "localRegistryCache": {
-                            "type": "object",
-                            "title": "Local registry cache",
-                            "description": "Caching container registry within the cluster.",
-                            "required": [
-                                "enabled",
-                                "port"
-                            ],
-                            "additionalProperties": false,
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean",
-                                    "title": "Enable",
-                                    "description": "Enabling this will deploy the Zot registry service in the cluster. To make use of it as a pull-through cache, you also have to specify registries to cache images for.",
-                                    "default": false
-                                },
-                                "mirroredRegistries": {
-                                    "type": "array",
-                                    "title": "Registries to cache",
-                                    "description": "Here you must specify each registry to cache container images for. Please also make sure to have an entry for each registry in Global > Components > Containerd > Container registries.",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "default": []
-                                },
-                                "port": {
-                                    "type": "integer",
-                                    "title": "Service port",
-                                    "description": "NodePort used by the local registry service.",
-                                    "default": 32767
                                 }
                             }
                         },

--- a/helm/cluster-vsphere/values.yaml
+++ b/helm/cluster-vsphere/values.yaml
@@ -277,12 +277,7 @@ global:
       selinux:
         enabled: false
   connectivity:
-    containerRegistries: {}
     dns: {}
-    localRegistryCache:
-      enabled: false
-      mirroredRegistries: []
-      port: 32767
     network:
       controlPlaneEndpoint:
         ipPoolName: wc-cp-ips


### PR DESCRIPTION
It was only used in the `config.toml` which on its own has been an orphan. We nowadays render this configs from the `cluster` chart.